### PR TITLE
mptcp:dss: use 32-bit DACK when possible

### DIFF
--- a/gtests/net/mptcp/dss/dss_ssn_specified_server.pkt
+++ b/gtests/net/mptcp/dss/dss_ssn_specified_server.pkt
@@ -26,5 +26,11 @@
 +0     < P. 1:11(10) ack 2001 win 225 <dss dack8=2001 dsn8=1 ssn=1 dll=10 nocs, nop, nop>
 +0     > .  2001:2001(0) ack 11 <dss dack8=11 nocs>
 0.3  read(4, ..., 10) = 10
+
+// send 1 more data segment, this time dack8 will have to be used: server sent dsn8
++0   write(4, ..., 1000) = 1000
++0     > P. 2001:3001(1000) ack 11 <dss dack8=11 dsn8=2001 ssn=2001 dll=1000 nocs, nop, nop>
++0.1   < .  11:11(0) ack 3001 win 225 <dss dack8=3001 dsn8=10 ssn=1 dll=0 nocs, nop, nop>
+
 +0   close(4) = 0
-+0     > F. 2001:2001(0) ack 11 <dss dack8=11 dsn8=2001 ssn=0 dll=1 nocs fin, nop, nop>
++0     > F. 3001:3001(0) ack 11 <dss dack8=11 dsn8=3001 ssn=0 dll=1 nocs fin, nop, nop>

--- a/gtests/net/mptcp/dss/dss_ssn_specified_server.pkt
+++ b/gtests/net/mptcp/dss/dss_ssn_specified_server.pkt
@@ -15,11 +15,11 @@
 
 // send 2 data segments and ack them
 +0   write(4, ..., 1000) = 1000
-+0     > P. 1:1001(1000) ack 1 <dss dack8=1 dsn8=1 ssn=1 dll=1000 nocs, nop, nop>
++0     > P. 1:1001(1000) ack 1 <dss dack4=1 dsn8=1 ssn=1 dll=1000 nocs, nop, nop>
 +0.1   < . 1:1(0) ack 1001 win 225 <dss dack8=1001 dsn8=1 ssn=1 dll=0 nocs, nop, nop>
 
 +0   write(4, ..., 1000) = 1000
-+0     > P. 1001:2001(1000) ack 1 <dss dack8=1 dsn8=1001 ssn=1001 dll=1000 nocs, nop, nop>
++0     > P. 1001:2001(1000) ack 1 <dss dack4=1 dsn8=1001 ssn=1001 dll=1000 nocs, nop, nop>
 +0.1   < .  1:1(0) ack 2001 win 225 <dss dack8=2001 dsn8=1 ssn=1 dll=0 nocs, nop, nop>
 
 // read and ack 1 data segment

--- a/gtests/net/mptcp/dss/mpc_with_data_client.pkt
+++ b/gtests/net/mptcp/dss/mpc_with_data_client.pkt
@@ -21,7 +21,7 @@
 +0.01   > P. 1:1001(1000) ack 1 <nop, nop, TS val 100 ecr 700, mpcapable v1 flags[flag_h] key[ckey,skey] mpcdatalen 1000, nop, nop>
 +0.01   < .  1:1(0) ack 1001 win 225 <dss dack8=1001 nocs>
 +0.1 write(3, ..., 500) = 500
-+0.01   > P. 1001:1501(500) ack 1 <nop, nop, TS val 100 ecr 700, dss dack8=1 dsn8=1001 ssn=1001 dll=500 nocs, nop, nop>
++0.01   > P. 1001:1501(500) ack 1 <nop, nop, TS val 100 ecr 700, dss dack4=1 dsn8=1001 ssn=1001 dll=500 nocs, nop, nop>
 +0.01   < .  1:201(200) ack 1501 win 225 <dss dack8=1501 dsn8=1 ssn=1 dll=200 nocs, nop, nop>
 +0.01   > .  1501:1501(0) ack 201 <nop, nop, TS val 100 ecr 700, dss dack8=201 dll=0 nocs>
 +0.1 read(3, ..., 200) = 200


### PR DESCRIPTION
Since "mptcp: Use 32-bit DATA_ACK when possible" patch from @cpaasch ,
recently sent to net-next Linux repo, 32-bit DATA_ACK is now used by
default. This changes the default behaviour and that's why some
packetdrill tests need to be adapted.

Cc: @dcaratti  @pabeni
Signed-off-by: Matthieu Baerts <matthieu.baerts@tessares.net>