### PR TITLE
Remove duplicate code in dss_inbound_parser

### DIFF
--- a/gtests/net/packetdrill/mptcp.c
+++ b/gtests/net/packetdrill/mptcp.c
@@ -1392,10 +1392,10 @@ int dss_inbound_parser(struct packet *packet_to_modify,
 		struct dack *dack_live	= (struct dack*)((u32*)dss_opt_live+1);
 		struct dack *dack_script= (struct dack*)((u32*)dss_opt_script+1);
 
-		// dack4
-		if(!dss_opt_script->data.dss.flag_a){
+		if(!dss_opt_script->data.dss.flag_a)
 			set_dack4(dack_live, dack_script);
-		}
+		else
+			set_dack8(dack_live, dack_script);
 	}
 	subflow->ssn += tcp_payload_length;
 	return STATUS_OK;

--- a/gtests/net/packetdrill/mptcp.c
+++ b/gtests/net/packetdrill/mptcp.c
@@ -1132,7 +1132,7 @@ int dss_inbound_parser(struct packet *packet_to_modify,
 			set_dack8(dack_live, dack_script);
 			set_dsn4(dsn_live, dsn_script);
 
-			if(dss_opt_script->length == TCPOLEN_DSS_DACK4_DSN4){
+			if(dss_opt_script->length == TCPOLEN_DSS_DACK8_DSN4){
 				//Compute checksum
 				struct {
 					u64 dsn;
@@ -1176,7 +1176,7 @@ int dss_inbound_parser(struct packet *packet_to_modify,
 			set_dack4(dack_live, dack_script);
 			set_dsn8(dsn_live, dsn_script);
 
-			if(dss_opt_script->length == TCPOLEN_DSS_DACK4_DSN4){
+			if(dss_opt_script->length == TCPOLEN_DSS_DACK4_DSN8){
 				//Compute checksum
 				struct {
 					u64 dsn;
@@ -1217,7 +1217,7 @@ int dss_inbound_parser(struct packet *packet_to_modify,
 			set_dack8(dack_live, dack_script);
 			set_dsn8(dsn_live, dsn_script);
 
-			if(dss_opt_script->length == TCPOLEN_DSS_DACK4_DSN4){
+			if(dss_opt_script->length == TCPOLEN_DSS_DACK8_DSN8){
 				//Compute checksum
 				struct {
 					u64 dsn;
@@ -1257,7 +1257,7 @@ int dss_inbound_parser(struct packet *packet_to_modify,
 		if(!dss_opt_script->data.dss.flag_m){
 			set_dsn4(dsn_live, dsn_script);
 
-			if(dss_opt_script->length == TCPOLEN_DSS_DACK4_DSN4){
+			if(dss_opt_script->length == TCPOLEN_DSS_DSN4){
 				//Compute checksum
 				struct {
 					u64 dsn;
@@ -1291,7 +1291,7 @@ int dss_inbound_parser(struct packet *packet_to_modify,
 		}else{
 			set_dsn8(dsn_live, dsn_script);
 
-			if(dss_opt_script->length == TCPOLEN_DSS_DACK4_DSN4){
+			if(dss_opt_script->length == TCPOLEN_DSS_DSN8){
 				//Compute checksum
 				struct {
 					u64 dsn;


### PR DESCRIPTION
This series extracts the common code from dss_inbound_parser and fixes a number of issues related to the duplication.