### PR TITLE
remove win size for out packets

### DIFF
--- a/gtests/net/mptcp/add_addr/add_addr_client.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr_client.pkt
@@ -12,13 +12,13 @@
 +0.0  connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
 0.0     > S 0:0(0) <mss 1460,sackOK,TS val 100 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
 +0.0    < S. 0:0(0) ack 1 win 65535 <mss 1460,sackOK,TS val 700 ecr 100,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey=2]>
-+0.0    > . 1:1(0) ack 1 win 256 <nop,nop,TS val 100 ecr 700,mpcapable v1 flags[flag_h] key[ckey,skey]>
++0.0    > . 1:1(0) ack 1 <nop,nop,TS val 100 ecr 700,mpcapable v1 flags[flag_h] key[ckey,skey]>
 0.200 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
 0.205 fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
 
 +0.01 write(3,..., 100) = 100
-+0.0    > P. 1:101(100) ack 1 win 256 <nop,nop,TS val 305 ecr 700,mpcapable v1 flags[flag_h] key[ckey,skey] mpcdatalen 100,nop,nop>
++0.0    > P. 1:101(100) ack 1 <nop,nop,TS val 305 ecr 700,mpcapable v1 flags[flag_h] key[ckey,skey] mpcdatalen 100,nop,nop>
 +0.0    < . 1:1(0) ack 101 win 256 <nop,nop,TS val 705 ecr 305,add_address addr[saddr] hmac=auto,dss dack8=101 dll=0 nocs>
 
 +0.4 close(3) = 0
-+0.0   > F. 101:101(0) ack 1 win 256 <nop, nop,TS val 494 ecr 700,dss dack4=1 dsn8=101 ssn=0 dll=1 nocs fin, nop, nop>
++0.0   > F. 101:101(0) ack 1 <nop, nop,TS val 494 ecr 700,dss dack4=1 dsn8=101 ssn=0 dll=1 nocs fin, nop, nop>

--- a/gtests/net/mptcp/add_addr/add_addr_server.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr_server.pkt
@@ -18,7 +18,7 @@
 
 // read and ack 1 data segment
 +0.01  < P. 1:1001(1000) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=1 ssn=1 dll=1000 nocs>
-+0     > . 1:1(0) ack 1001 win 264 <add_address addr[saddr] hmac=auto,dss dack8=1001 ssn=1 dll=0 nocs>
++0     > . 1:1(0) ack 1001 <add_address addr[saddr] hmac=auto,dss dack8=1001 ssn=1 dll=0 nocs>
 0.3  read(4, ..., 1000) = 1000
 
 +0   close(4) = 0

--- a/gtests/net/mptcp/dss/dss_ssn_specified_client.pkt
+++ b/gtests/net/mptcp/dss/dss_ssn_specified_client.pkt
@@ -13,14 +13,14 @@
 +0.0  connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
 +0.0   > S 0:0(0) <mss 1460,sackOK,TS val 100 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
 +0.0   < S. 0:0(0) ack 1 win 65535 <mss 1460,sackOK,TS val 700 ecr 100,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey=2] >
-+0.0   > . 1:1(0) ack 1 win 256 <nop, nop, TS val 100 ecr 700,mpcapable v1 flags[flag_h] key[ckey,skey]>
++0.0   > . 1:1(0) ack 1 <nop, nop, TS val 100 ecr 700,mpcapable v1 flags[flag_h] key[ckey,skey]>
 0.200 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
 0.205 fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
 +0.1   < P. 1:1001(1000) ack 1 win 450  <nop, nop, dss dack8=1 dsn8=1 ssn=1 dll=1000 nocs>
-+0.0   > . 1:1(0) ack 1001 win 264 <nop, nop, TS val 100 ecr 700,dss dack8=1001 ssn=1 dll=0 nocs>
++0.0   > . 1:1(0) ack 1001 <nop, nop, TS val 100 ecr 700,dss dack8=1001 ssn=1 dll=0 nocs>
 0.3  read(3, ..., 1000) = 1000
 +0.0 write(3,..., 100) = 100
-+0.0   > P. 1:101(100) ack 1001 win 264 <nop, nop, TS val 100 ecr 700, dss dack8=1001 dsn8=1 ssn=1 dll=100 nocs, nop, nop>
++0.0   > P. 1:101(100) ack 1001 <nop, nop, TS val 100 ecr 700, dss dack8=1001 dsn8=1 ssn=1 dll=100 nocs, nop, nop>
 0.4 close(3) = 0
 // SSN should be 0 for DATA-FIN packets carrying no data at all
-+0.0   > F. 101:101(0) ack 1001 win 264 <nop, nop,TS val 100 ecr 700,dss dack8=1001 dsn8=101 ssn=0 dll=1 nocs fin, nop, nop>
++0.0   > F. 101:101(0) ack 1001 <nop, nop,TS val 100 ecr 700,dss dack8=1001 dsn8=101 ssn=0 dll=1 nocs fin, nop, nop>

--- a/gtests/net/mptcp/dss/mpc_with_data_client.pkt
+++ b/gtests/net/mptcp/dss/mpc_with_data_client.pkt
@@ -13,7 +13,7 @@
 +0.0  connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
 +0.01   > S 0:0(0) <mss 1460,sackOK,TS val 100 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
 +0.01   < S. 0:0(0) ack 1 win 65535 <mss 1460,sackOK,TS val 700 ecr 100,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey=2] >
-+0.01  > . 1:1(0) ack 1 win 256 <nop, nop, TS val 100 ecr 700,mpcapable v1 flags[flag_h] key[ckey,skey]>
++0.01  > . 1:1(0) ack 1 <nop, nop, TS val 100 ecr 700,mpcapable v1 flags[flag_h] key[ckey,skey]>
 0.200 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
 0.205 fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
 

--- a/gtests/net/mptcp/dss/mpc_with_data_server.pkt
+++ b/gtests/net/mptcp/dss/mpc_with_data_server.pkt
@@ -14,7 +14,7 @@
 +0    accept(3, ..., ...) = 4
 
 +0.01   < P. 1:101(100) ack 1 win 225 <mpcapable v1 flags[flag_h] key[ckey=2,skey] mpcdatalen 100, nop, nop>
-+0.01   > . 1:1(0) ack 101 win 256 <dss dack8=101 nocs>
++0.01   > . 1:1(0) ack 101 <dss dack8=101 nocs>
 
 // send 1 data segments and ack them
 +0    write(4, ..., 1000) = 1000

--- a/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_flagB.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_flagB.pkt
@@ -12,7 +12,7 @@
 +0.0  connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
 +0.0   > S 0:0(0) <mss 1460,sackOK,TS val 100 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
 +0.0   < S. 0:0(0) ack 1 win 65535 <mss 1460,sackOK,TS val 700 ecr 100,nop,wscale 8,mpcapable v1 flags[flag_b,flag_h] key[skey=2] >
-+0.0   > . 1:1(0) ack 1 win 256 <nop,nop,TS val 100 ecr 700>
++0.0   > . 1:1(0) ack 1  <nop,nop,TS val 100 ecr 700>
 0.200 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
 0.200 fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
 

--- a/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_flagH.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_flagH.pkt
@@ -12,7 +12,7 @@
 +0.0  connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
 +0.0   > S 0:0(0) <mss 1460,sackOK,TS val 100 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
 +0.0   < S. 0:0(0) ack 1 win 65535 <mss 1460,sackOK,TS val 700 ecr 100,nop,wscale 8,mpcapable v1 flags 0x0 key[skey=2] >
-+0.0   > . 1:1(0) ack 1 win 256 <nop,nop,TS val 100 ecr 700>
++0.0   > . 1:1(0) ack 1 <nop,nop,TS val 100 ecr 700>
 0.200 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
 0.200 fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
 

--- a/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_wrongver.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_wrongver.pkt
@@ -12,7 +12,7 @@
 +0.0  connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
 +0.0   > S 0:0(0) <mss 1460,sackOK,TS val 100 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
 +0.0   < S. 0:0(0) ack 1 win 65535 <mss 1460,sackOK,TS val 700 ecr 100,nop,wscale 8,mpcapable v0 flags[flag_h] key[ckey=3,skey=2] >
-+0.0   > . 1:1(0) ack 1 win 256 <nop,nop,TS val 100 ecr 700>
++0.0   > . 1:1(0) ack 1 <nop,nop,TS val 100 ecr 700>
 0.200 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
 0.200 fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
 

--- a/gtests/net/mptcp/mp_capable/v1_mp_capable_connect_no_cs.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_mp_capable_connect_no_cs.pkt
@@ -12,6 +12,6 @@
 +0.0  connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
 +0.0   > S 0:0(0) <mss 1460,sackOK,TS val 100 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
 +0.0   < S. 0:0(0) ack 1 win 65535 <mss 1460,sackOK,TS val 700 ecr 100,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey=2] >
-+0.0   > . 1:1(0) ack 1 win 256 <nop,nop,TS val 100 ecr 700,mpcapable v1 flags[flag_h] key[ckey,skey] >
++0.0   > . 1:1(0) ack 1 <nop,nop,TS val 100 ecr 700,mpcapable v1 flags[flag_h] key[ckey,skey] >
 0.200 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
 0.200 fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking

--- a/gtests/net/mptcp/mp_join/mp_join_client.pkt
+++ b/gtests/net/mptcp/mp_join/mp_join_client.pkt
@@ -9,21 +9,21 @@
 +0.0  fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
 
 +0.0 connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
-+0.0 > addr[caddr0] > addr[saddr0] S 0:0(0) win 65535 <mss 1460,sackOK,TS val 4074410674 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
++0.0 > addr[caddr0] > addr[saddr0] S 0:0(0) <mss 1460,sackOK,TS val 4074410674 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
 +0.0 < S. 0:0(0) ack 1 win 65535 <mss 1460,sackOK,TS val 4074410674 ecr 4074410674,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey=2]>
-+0.0 > . 1:1(0) ack 1 win 256 <nop,nop,TS val 4074410674 ecr 4074410674,mpcapable v1 flags[flag_h] key[ckey,skey]>
++0.0 > . 1:1(0) ack 1 <nop,nop,TS val 4074410674 ecr 4074410674,mpcapable v1 flags[flag_h] key[ckey,skey]>
 +0.2 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
 +0.0 fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
 
 +1.0 write(3,..., 2) = 2
-+0.0 > P. 1:3(2) ack 1 win 256 <nop,nop,TS val 4074418292 ecr 4074410674,mpcapable v1 flags[flag_h] key[ckey,skey] mpcdatalen 2,nop,nop>
++0.0 > P. 1:3(2) ack 1 <nop,nop,TS val 4074418292 ecr 4074410674,mpcapable v1 flags[flag_h] key[ckey,skey] mpcdatalen 2,nop,nop>
 +0.0 < . 1:1(0) ack 3 win 256 <nop,nop,TS val 4074418293 ecr 4074418292,add_address addr[saddr1] hmac=auto,dss dack8=3 dll=0 nocs>
 
-+0.0 > > addr[saddr1] S 0:0(0) win 65535 <mss 1460,sackOK,TS val 448955294 ecr 0,nop,wscale 8,mp_join_syn backup=1 address_id=0 token=sha256_32(skey)>
++0.0 > > addr[saddr1] S 0:0(0) <mss 1460,sackOK,TS val 448955294 ecr 0,nop,wscale 8,mp_join_syn backup=1 address_id=0 token=sha256_32(skey)>
 +0.0 < S. 0:0(0) ack 1 win 65535 <mss 1460,sackOK,TS val 448955294 ecr 448955294,nop,wscale 8,mp_join_syn_ack backup=1 address_id=1 sender_hmac=auto>
-+0.0 > . 1:1(0) ack 1 win 256 <nop,nop,TS val 448955294 ecr 448955294,mp_join_ack sender_hmac=auto>
++0.0 > . 1:1(0) ack 1 <nop,nop,TS val 448955294 ecr 448955294,mp_join_ack sender_hmac=auto>
 +0.0 < . 1:1(0) ack 1 win 256 <nop,nop,TS val 448955294 ecr 448955294>
 
 +1.0 close(3) = 0
-+0.0 > addr[caddr0] > addr[saddr0] F. 3:3(0) ack 1 win 256 <nop,nop,TS val 4074418292 ecr 4074418293,dss dack4=1 dsn8=3 ssn=0 dll=1 nocs fin,nop,nop>
-+0.0 > > addr[saddr1] F. 1:1(0) ack 1 win 256 <nop,nop,TS val 448955294 ecr 448955294>
++0.0 > addr[caddr0] > addr[saddr0] F. 3:3(0) ack 1 <nop,nop,TS val 4074418292 ecr 4074418293,dss dack4=1 dsn8=3 ssn=0 dll=1 nocs fin,nop,nop>
++0.0 > > addr[saddr1] F. 1:1(0) ack 1 <nop,nop,TS val 448955294 ecr 448955294>

--- a/gtests/net/mptcp/mp_join/mp_join_server.pkt
+++ b/gtests/net/mptcp/mp_join/mp_join_server.pkt
@@ -12,18 +12,18 @@
 +0    listen(3, 1) = 0
 
 +0.0 < addr[caddr0] > addr[saddr0] S 0:0(0) win 65535 <mss 1460,sackOK,TS val 4074410674 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
-+0.0 > S. 0:0(0) ack 1 win 65535 <mss 1460,sackOK,TS val 4074410674 ecr 4074410674,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey]>
++0.0 > S. 0:0(0) ack 1 <mss 1460,sackOK,TS val 4074410674 ecr 4074410674,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey]>
 +0.0 < . 1:1(0) ack 1 win 256 <nop,nop,TS val 4074410674 ecr 4074410674,mpcapable v1 flags[flag_h] key[ckey=2,skey]>
 +0    accept(3, ..., ...) = 4
 
 +1.0 < P. 1:3(2) ack 1 win 256 <nop,nop,TS val 4074418292 ecr 4074410674,mpcapable v1 flags[flag_h] key[skey,ckey] mpcdatalen 2,nop,nop>
-+0.0 > . 1:1(0) ack 3 win 256 <nop,nop,TS val 4074418293 ecr 4074418292,add_address addr[saddr1] hmac=auto,dss dack8=3 dll=0 nocs>
++0.0 > . 1:1(0) ack 3 <nop,nop,TS val 4074418293 ecr 4074418292,add_address addr[saddr1] hmac=auto,dss dack8=3 dll=0 nocs>
 
 // create subflow
 +0.0 < addr[caddr1] > addr[saddr1] S 0:0(0) win 65535 <mss 1460,sackOK,TS val 448955294 ecr 0,nop,wscale 8,mp_join_syn backup=1 address_id=2 token=sha256_32(skey)>
-+0.0 > S. 0:0(0) ack 1 win 65535 <mss 1460,sackOK,TS val 448955294 ecr 448955294,nop,wscale 8,mp_join_syn_ack backup=1 address_id=0 sender_hmac=auto>
++0.0 > S. 0:0(0) ack 1 <mss 1460,sackOK,TS val 448955294 ecr 448955294,nop,wscale 8,mp_join_syn_ack backup=1 address_id=0 sender_hmac=auto>
 +0.0 < . 1:1(0) ack 1 win 256 <nop,nop,TS val 448955294 ecr 448955294,mp_join_ack sender_hmac=auto>
-+0.0 > . 1:1(0) ack 1 win 256 <nop,nop,TS val 448955294 ecr 448955294,dss dack4=3>
++0.0 > . 1:1(0) ack 1 <nop,nop,TS val 448955294 ecr 448955294,dss dack4=3>
 
 // close connection
 +0.0 < addr[caddr0] > addr[saddr0] F. 3:3(0) ack 1 win 256 <nop,nop,TS val 4074418292 ecr 4074418293,dss dack4=1 dsn8=3 ssn=0 dll=1 nocs fin,nop,nop>


### PR DESCRIPTION
Some systems send initial window size which is less than 65535.
To be compatible with different systems, remove win size for our packets.

Signed-off-by: Xiumei Mu <xmu@redhat.com>