### PR TITLE
mptcp: fix path of 'common' dir

### DIFF
--- a/gtests/net/mptcp/add_addr/add_addr_client.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr_client.pkt
@@ -2,7 +2,7 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-+0   `../mptcp/common/client.sh`
++0   `../common/client.sh`
 
 0.0   socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
 +0.0  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0

--- a/gtests/net/mptcp/mp_join/mp_join_client.pkt
+++ b/gtests/net/mptcp/mp_join/mp_join_client.pkt
@@ -1,7 +1,7 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-+0   `../mptcp/common/client.sh`
++0   `../common/client.sh`
 
 +0.0  socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
 +0.0  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0

--- a/gtests/net/mptcp/mp_join/mp_join_server.pkt
+++ b/gtests/net/mptcp/mp_join/mp_join_server.pkt
@@ -1,7 +1,7 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-+0    `../mptcp/common/server.sh`
++0    `../common/server.sh`
 
 0.0   socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
 +0.0  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0


### PR DESCRIPTION
From what I see with how `common/defaults.sh` and mainly `common/set_sysctls.py` (in `tcp` dir) are used, we should not go one directory up to reach `mptcp` folder.

In this case, we can continue to run from `gtests/net dir` the command:

    ./packetdrill/run_all.py