### PR TITLE
fix data-fin in 'dss' and 'add_addr' tests

### DIFF
--- a/gtests/net/mptcp/add_addr/add_addr_client.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr_client.pkt
@@ -21,4 +21,4 @@
 +0.0    < . 1:1(0) ack 101 win 256 <nop,nop,TS val 705 ecr 305,add_address addr[saddr] hmac=auto,dss dack8=101 dll=0 nocs>
 
 +0.4 close(3) = 0
-+0.0   > F. 101:101(0) ack 1 <nop, nop,TS val 494 ecr 700,dss dack4=1 dsn8=101 ssn=0 dll=1 nocs fin, nop, nop>
++0.0   > . 101:101(0) ack 1 <nop, nop,TS val 494 ecr 700,dss dack4=1 dsn8=101 ssn=0 dll=1 nocs fin, nop, nop>

--- a/gtests/net/mptcp/add_addr/add_addr_server.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr_server.pkt
@@ -22,4 +22,4 @@
 +0.3  read(4, ..., 1000) = 1000
 
 +0    close(4) = 0
-+0     > F. 1:1(0) ack 1001 <dss dack8=1001 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
++0     > . 1:1(0) ack 1001 <dss dack8=1001 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>

--- a/gtests/net/mptcp/dss/dss_ssn_specified_client.pkt
+++ b/gtests/net/mptcp/dss/dss_ssn_specified_client.pkt
@@ -21,6 +21,7 @@
 +0.3  read(3, ..., 1000) = 1000
 +0.0 write(3,..., 100) = 100
 +0.0   > P. 1:101(100) ack 1001 <nop, nop, TS val 100 ecr 700, dss dack8=1001 dsn8=1 ssn=1 dll=100 nocs, nop, nop>
++0.0   < .  1001:1001(0) ack 101 win 450 <dss dack8=101 nocs>
 +0.4 close(3) = 0
-// SSN should be 0 for DATA-FIN packets carrying no data at all
-+0.0   > F. 101:101(0) ack 1001 <nop, nop,TS val 100 ecr 700,dss dack8=1001 dsn8=101 ssn=0 dll=1 nocs fin, nop, nop>
++0.0   > . 101:101(0) ack 1001 <nop, nop,TS val 100 ecr 700,dss dack8=1001 dsn8=101 ssn=0 dll=1 nocs fin, nop, nop>
++0.0   > F. 101:101(0) ack 1001 <nop, nop,TS val 100 ecr 700, dss dack8=1001 dsn8=101 ssn=0 dll=1 nocs fin, nop, nop>

--- a/gtests/net/mptcp/dss/dss_ssn_specified_server.pkt
+++ b/gtests/net/mptcp/dss/dss_ssn_specified_server.pkt
@@ -30,7 +30,8 @@
 // send 1 more data segment, this time dack8 will have to be used: server sent dsn8
 +0   write(4, ..., 1000) = 1000
 +0     > P. 2001:3001(1000) ack 11 <dss dack8=11 dsn8=2001 ssn=2001 dll=1000 nocs, nop, nop>
-+0.1   < .  11:11(0) ack 3001 win 225 <dss dack8=3001 dsn8=10 ssn=1 dll=0 nocs, nop, nop>
++0     < .  11:11(0) ack 3001 win 225 <dss dack8=3001 dsn8=10 ssn=1 dll=0 nocs, nop, nop>
 
 +0   close(4) = 0
++0     > . 3001:3001(0) ack 11 <dss dack8=11 dsn8=3001 ssn=0 dll=1 nocs fin, nop, nop>
 +0     > F. 3001:3001(0) ack 11 <dss dack8=11 dsn8=3001 ssn=0 dll=1 nocs fin, nop, nop>

--- a/gtests/net/mptcp/dss/mpc_with_data_server.pkt
+++ b/gtests/net/mptcp/dss/mpc_with_data_server.pkt
@@ -24,4 +24,5 @@
 // read 100 bytes from the MPC+data
 +0.01 read(4, ..., 100) = 100
 +0    close(4) = 0
++0      > . 1001:1001(0) ack 101 <dss dack8=101 dsn8=1001 ssn=0 dll=1 nocs fin, nop, nop>
 +0      > F. 1001:1001(0) ack 101 <dss dack8=101 dsn8=1001 ssn=0 dll=1 nocs fin, nop, nop>


### PR DESCRIPTION
on recent kernels (5.9-rc1+), a call to close() causes the transmission of a
regular ack having the DATA FIN bit set. This bit is acknowledged by the
peer and then subflows are closed with TCP FIN: adjust tests in the
'dss' and 'add_addr' folders accordingly.

Closes: https://github.com/multipath-tcp/mptcp_net-next/issues/69
Signed-off-by: Davide Caratti <dcaratti@redhat.com>