### PR TITLE
don't expect 'backup' flags in the MP_JOIN SYN in mp_join_client

### DIFF
--- a/gtests/net/mptcp/mp_join/mp_join_client.pkt
+++ b/gtests/net/mptcp/mp_join/mp_join_client.pkt
@@ -19,8 +19,8 @@
 +0.0 > P. 1:3(2) ack 1 <nop,nop,TS val 4074418292 ecr 4074410674,mpcapable v1 flags[flag_h] key[ckey,skey] mpcdatalen 2,nop,nop>
 +0.0 < . 1:1(0) ack 3 win 256 <nop,nop,TS val 4074418293 ecr 4074418292,add_address addr[saddr1] hmac=auto,dss dack8=3 dll=0 nocs>
 
-+0.0 > > addr[saddr1] S 0:0(0) <mss 1460,sackOK,TS val 448955294 ecr 0,nop,wscale 8,mp_join_syn backup=1 address_id=0 token=sha256_32(skey)>
-+0.0 < S. 0:0(0) ack 1 win 65535 <mss 1460,sackOK,TS val 448955294 ecr 448955294,nop,wscale 8,mp_join_syn_ack backup=1 address_id=1 sender_hmac=auto>
++0.0 > > addr[saddr1] S 0:0(0) <mss 1460,sackOK,TS val 448955294 ecr 0,nop,wscale 8,mp_join_syn address_id=0 token=sha256_32(skey)>
++0.0 < S. 0:0(0) ack 1 win 65535 <mss 1460,sackOK,TS val 448955294 ecr 448955294,nop,wscale 8,mp_join_syn_ack address_id=1 sender_hmac=auto>
 +0.0 > . 1:1(0) ack 1 <nop,nop,TS val 448955294 ecr 448955294,mp_join_ack sender_hmac=auto>
 +0.0 < . 1:1(0) ack 1 win 256 <nop,nop,TS val 448955294 ecr 448955294>
 


### PR DESCRIPTION
the additional server address is received via an ADD_ADDR, and there is
currently no way to create 'backup' subflows in this way, after the
upstream kernel removed hardcoded value for that flag. Fix the test
script accordingly.

Closes: https://github.com/multipath-tcp/mptcp_net-next/issues/81
Signed-off-by: Davide Caratti <dcaratti@redhat.com>