### PR TITLE
preliminary fix for mp_join

### DIFF
--- a/gtests/net/mptcp/mp_join/mp_join_client.pkt
+++ b/gtests/net/mptcp/mp_join/mp_join_client.pkt
@@ -22,8 +22,11 @@
 +0.0 > > addr[saddr1] S 0:0(0) <mss 1460,sackOK,TS val 448955294 ecr 0,nop,wscale 8,mp_join_syn address_id=0 token=sha256_32(skey)>
 +0.0 < S. 0:0(0) ack 1 win 65535 <mss 1460,sackOK,TS val 448955294 ecr 448955294,nop,wscale 8,mp_join_syn_ack address_id=1 sender_hmac=auto>
 +0.0 > . 1:1(0) ack 1 <nop,nop,TS val 448955294 ecr 448955294,mp_join_ack sender_hmac=auto>
-+0.0 < . 1:1(0) ack 1 win 256 <nop,nop,TS val 448955294 ecr 448955294>
++0.0 < . 1:1(0) ack 1 win 256 <nop,nop,TS val 448955294 ecr 448955294, dss dack8=3 nocs>
++0.0 < . 1:101(100) ack 1 win 256 <TS val 448955294 ecr 448955294, dss dack8=3 dsn8=1 ssn=1 dll=100 nocs>
++0.0 > . 1:1(0) ack 101 win 256 <nop, nop, TS val 448955294 ecr 448955294, add_address addr[saddr1], dss dack8=101 nocs>
++0.0 read (3, ..., 100) = 100
++0.1 close(3) = 0
++0.0 > addr[caddr0] > addr[saddr0] . 3:3(0) ack 1 <nop,nop,TS val 4074418292 ecr 4074418293,dss dack8=101 dsn8=3 ssn=0 dll=1 nocs fin,nop,nop>
++0.0 > addr[caddr0] > addr[saddr1] . 3:3(0) ack 1 <nop,nop,TS val 4074418292 ecr 4074418293,dss dack8=101 dsn8=3 ssn=0 dll=1 nocs fin,nop,nop>
 
-+1.0 close(3) = 0
-+0.0 > addr[caddr0] > addr[saddr0] F. 3:3(0) ack 1 <nop,nop,TS val 4074418292 ecr 4074418293,dss dack4=1 dsn8=3 ssn=0 dll=1 nocs fin,nop,nop>
-+0.0 > > addr[saddr1] F. 1:1(0) ack 1 <nop,nop,TS val 448955294 ecr 448955294>

--- a/gtests/net/mptcp/mp_join/mp_join_server_v4.pkt
+++ b/gtests/net/mptcp/mp_join/mp_join_server_v4.pkt
@@ -23,7 +23,7 @@
 +0.0 < addr[caddr1] > addr[saddr1] S 0:0(0) win 65535 <mss 1460,sackOK,TS val 448955294 ecr 0,nop,wscale 8,mp_join_syn backup=1 address_id=2 token=sha256_32(skey)>
 +0.0 > S. 0:0(0) ack 1 <mss 1460,sackOK,TS val 448955294 ecr 448955294,nop,wscale 8,mp_join_syn_ack backup=1 address_id=0 sender_hmac=auto>
 +0.0 < . 1:1(0) ack 1 win 256 <nop,nop,TS val 448955294 ecr 448955294,mp_join_ack sender_hmac=auto>
-+0.0 > . 1:1(0) ack 1 <nop,nop,TS val 448955294 ecr 448955294,dss dack4=3>
++0.0 > . 1:1(0) ack 1 <nop,nop,TS val 448955294 ecr 448955294,dss dack8=3 nocs>
 
 // close connection
 +0.0 < addr[caddr0] > addr[saddr0] F. 3:3(0) ack 1 win 256 <nop,nop,TS val 4074418292 ecr 4074418293,dss dack4=1 dsn8=3 ssn=0 dll=1 nocs fin,nop,nop>


### PR DESCRIPTION
in mp_join_client:
 - add missing DSS (it was missing and causing wrong TCP fallback on the
   client)
 - add an echoed add_address so the client doesn't retry it in subsequent DSS
 - fix the DACK length in one out of the 2 FIN packets (DSN=1 was 64-bit,
   kernel is expected to reply with 64-bit DACK)

in mp_join_server:
 - fix the DACK length (DSN=3 was 64-bit, kernel should reply with 64-bit
   DACK)
 - add missing "no_checksum"

Signed-off-by: Davide Caratti <dcaratti@redhat.com>