### PR TITLE
send inbound ACK after outbound DATAFIN after a call to close()

### DIFF
--- a/gtests/net/mptcp/dss/dss_ssn_specified_client.pkt
+++ b/gtests/net/mptcp/dss/dss_ssn_specified_client.pkt
@@ -24,4 +24,5 @@
 +0.0   < .  1001:1001(0) ack 101 win 450 <dss dack8=101 nocs>
 +0.4 close(3) = 0
 +0.0   > . 101:101(0) ack 1001 <nop, nop,TS val 100 ecr 700,dss dack8=1001 dsn8=101 ssn=0 dll=1 nocs fin, nop, nop>
-+0.0   > F. 101:101(0) ack 1001 <nop, nop,TS val 100 ecr 700, dss dack8=1001 dsn8=101 ssn=0 dll=1 nocs fin, nop, nop>
++0.0   < . 1001:1001(0) ack 101 win 450 <dss dack8=102 nocs>
++0.0   > F. 101:101(0) ack 1001 <nop, nop,TS val 100 ecr 700, dss dack8=1001 nocs>

--- a/gtests/net/mptcp/dss/dss_ssn_specified_server.pkt
+++ b/gtests/net/mptcp/dss/dss_ssn_specified_server.pkt
@@ -34,4 +34,5 @@
 
 +0   close(4) = 0
 +0     > . 3001:3001(0) ack 11 <dss dack8=11 dsn8=3001 ssn=0 dll=1 nocs fin, nop, nop>
-+0     > F. 3001:3001(0) ack 11 <dss dack8=11 dsn8=3001 ssn=0 dll=1 nocs fin, nop, nop>
++0     < . 11:11(0) ack 3001 win 225 <dss dack8=3002 nocs>
++0     > F. 3001:3001(0) ack 11 <dss dack8=11 nocs>

--- a/gtests/net/mptcp/dss/mpc_with_data_server.pkt
+++ b/gtests/net/mptcp/dss/mpc_with_data_server.pkt
@@ -25,4 +25,5 @@
 +0.01 read(4, ..., 100) = 100
 +0    close(4) = 0
 +0      > . 1001:1001(0) ack 101 <dss dack8=101 dsn8=1001 ssn=0 dll=1 nocs fin, nop, nop>
-+0      > F. 1001:1001(0) ack 101 <dss dack8=101 dsn8=1001 ssn=0 dll=1 nocs fin, nop, nop>
++0      < .  101:101(0) ack 1001 win 225 <dss dack8=1002 nocs>
++0      > F. 1001:1001(0) ack 101 <dss dack8=101 nocs>


### PR DESCRIPTION
otherwise packetdrill will need to wait 60 seconds before getting the
TCP FIN packet.

Closes: https://github.com/multipath-tcp/mptcp_net-next/issues/98