### PR TITLE
mptcp: make AF_ALG failure fatal

### DIFF
--- a/gtests/net/packetdrill/mptcp_utils.c
+++ b/gtests/net/packetdrill/mptcp_utils.c
@@ -236,7 +236,7 @@ static int linux_af_alg_socket(const char *type, const char *name)
 
 	s = socket(AF_ALG, SOCK_SEQPACKET, 0);
 	if (s < 0) {
-		DEBUGP("%s: Failed to open AF_ALG socket: %s",
+		die("%s: Failed to open AF_ALG socket: %s\n",
 			   __func__, strerror(errno));
 		return -1;
 	}


### PR DESCRIPTION
mptcp hmac computation silently fails when AF_ALG socket creation fails.
All hmacs are then 0 which gives errors that do point to a hmac issue but
not torwards a kernel config problem.

../packetdrill/packetdrill add_addr_server.pkt  --non_fatal=packet
add_addr_server.pkt:21: warning handling packet: MPTCP option mismatch: 30
script packet:  [..]<add_address address_id: 5 ipv4: 192.168.122.83 hmac: 0,dss [..]
actual packet:  [..]<add_address address_id: 5 ipv4: 192.168.122.83 hmac: 12700723542233333669,dss [..]

after:
../../packetdrill/packetdrill add_addr_server.pkt
linux_af_alg_socket: Failed to open AF_ALG socket: Address family not supported by protocol

i.e., fail at the problems source.  This doesn't affect scripts that do
not make calls to the mptcp hmac related functions.

Signed-off-by: Florian Westphal <fw@strlen.de>