### PR TITLE
mptcp: fix mp_fastclose key byte order

### DIFF
--- a/gtests/net/packetdrill/mptcp.c
+++ b/gtests/net/packetdrill/mptcp.c
@@ -2178,7 +2178,7 @@ int mptcp_subtype_mp_fastclose(struct packet *packet_to_modify,
 
 	if(dss_opt_script->data.mp_fastclose.receiver_key == UNDEFINED){ // <mp_fastclose>
 		if(direction == DIRECTION_INBOUND)
-			dss_opt_script->data.mp_fastclose.receiver_key = htonll(mp_state.kernel_key);
+			dss_opt_script->data.mp_fastclose.receiver_key = mp_state.kernel_key;
 		else if(direction == DIRECTION_OUTBOUND)
 			dss_opt_script->data.mp_fastclose.receiver_key = dss_opt_live->data.mp_fastclose.receiver_key;
 		else


### PR DESCRIPTION
1      < . 1002:1002(0) win 32792 <mp_fastclose>

doesn't work.  The kernel doesn't like the included key because
it is sent as host-endian instead of network byte order.

kernel.key is already in network byte order, so the extra htonll
needs to be removed.

This makes a test script using fastclose work with my fastclose
mptcp-next kernel branch.

Signed-off-by: Florian Westphal <fw@strlen.de>