### PR TITLE
Alg bind err

### DIFF
--- a/gtests/net/packetdrill/mptcp_utils.c
+++ b/gtests/net/packetdrill/mptcp_utils.c
@@ -244,7 +244,7 @@ static int linux_af_alg_socket(const char *type, const char *name)
 	memset(&sa, 0, sizeof(sa));
 	sa.salg_family = AF_ALG;
 	strncpy((char *) sa.salg_type, type, sizeof(sa.salg_type));
-	strncpy((char *) sa.salg_name, name, sizeof(sa.salg_type));
+	strncpy((char *) sa.salg_name, name, sizeof(sa.salg_name));
 	if (bind(s, (struct sockaddr *) &sa, sizeof(sa)) < 0) {
 		die("%s: Failed to bind AF_ALG socket(%s,%s): %s\n",
 			   __func__, type, name, strerror(errno));

--- a/gtests/net/packetdrill/mptcp_utils.c
+++ b/gtests/net/packetdrill/mptcp_utils.c
@@ -246,7 +246,7 @@ static int linux_af_alg_socket(const char *type, const char *name)
 	strncpy((char *) sa.salg_type, type, sizeof(sa.salg_type));
 	strncpy((char *) sa.salg_name, name, sizeof(sa.salg_type));
 	if (bind(s, (struct sockaddr *) &sa, sizeof(sa)) < 0) {
-		DEBUGP("%s: Failed to bind AF_ALG socket(%s,%s): %s",
+		die("%s: Failed to bind AF_ALG socket(%s,%s): %s\n",
 			   __func__, type, name, strerror(errno));
 		close(s);
 		return -1;


### PR DESCRIPTION
Two simple commits:

* mptcp: make ALG bind failure fatal: If the algo is not supported -- i.e. CRYPTO_SHA1 kconfig not enabled -- better to fail at the problems source instead of just print a message in debug and continue.

* mptcp: do not limit ALG algo to 14 char: We were wrongly taking the size of 'type' instead of 'name' (but 14 chars was enough for us)