### PR TITLE
mptcp: add regression test for divide by 0 error

### DIFF
--- a/gtests/net/mptcp/regressions/unconnected_read.pkt
+++ b/gtests/net/mptcp/regressions/unconnected_read.pkt
@@ -1,0 +1,11 @@
+// This test case covers the regression fixed by ("mptcp: be careful on MPTCP-level ack.")
+// bad read on on unconnected socket
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
+0.0   socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0  fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
++0.0  fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+
++0.100 read(3, ..., 1000) = -1 ENOTCONN (Socket is not connected)
+


### PR DESCRIPTION
This test a plain, failing, read on a fresh, unconnected
socket.

Signed-off-by: Paolo Abeni <pabeni@redhat.com>