### PR TITLE
mptcp: add fastclose test cases

### DIFF
--- a/gtests/net/mptcp/fastclose/receive_fastclose_with_ack.pkt
+++ b/gtests/net/mptcp/fastclose/receive_fastclose_with_ack.pkt
@@ -1,0 +1,36 @@
+// connection initiated by packetdrill
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
++0    `../common/server.sh`
+
++0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
+
++0    bind(3, ..., ...) = 0
++0    listen(3, 1) = 0
++0.0    < addr[caddr0] > addr[saddr0] S 0:0(0) win 65535 <mss 1460,nop,wscale 7,mpcapable v1 flags[flag_h] nokey>
++0.0 > S. 0:0(0) ack 1 <mss 1460,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey]>
++0.0 < . 1:1(0) ack 1 win 256 <mpcapable v1 flags[flag_h] key[ckey=2,skey]>
++0    accept(3, ..., ...) = 4
+
++0.0  < P. 1:1001(1000) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=1 ssn=1 dll=1000 nocs>
++0.0  >  . 1:1(0) ack 1001 win 264 <dss dack8=1001 nocs>
+
+// send ack fastclose with a key that should not match.
++0    < . 1001:1001(0) win 450 <mp_fastclose ckey=42 >
+
+// more data, expect ack
++1.0  < P. 1001:2001(1000) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=1001 ssn=1001 dll=1000 nocs>
++0.0  > . 1:1(0) ack 2001 win 272 <add_address addr[saddr1] hmac=auto,dss dack8=2001 nocs>
+
+// send another ack fastclose, this time with matching key
++0.1      < . 2001:2001(0) win 450 <mp_fastclose>
+// expect peer to reset all subflows now:
++0.01 > R. 1:1(0) ack 2001 win 272
+
+// more data, expect a reset and win0 (no socket anymore)
++1.0  < P. 2001:3001(1000) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=2001 ssn=2001 dll=1000 nocs>
++0.01 > R 1:1(0) ack 0 win 0
+
++0    close(4) = 0

--- a/gtests/net/mptcp/fastclose/receive_fastclose_with_ack_multi.pkt
+++ b/gtests/net/mptcp/fastclose/receive_fastclose_with_ack_multi.pkt
@@ -1,0 +1,47 @@
+// connection initiated by packetdrill
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
++0    `../common/server.sh`
+
++0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
+
++0    bind(3, ..., ...) = 0
++0    listen(3, 1) = 0
++0.0    < addr[caddr0] > addr[saddr0] S 0:0(0) win 65535 <mss 1460,nop,wscale 7,mpcapable v1 flags[flag_h] nokey>
++0.0 > S. 0:0(0) ack 1 <mss 1460,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey]>
++0.0 < . 1:1(0) ack 1 win 256 <mpcapable v1 flags[flag_h] key[ckey=2,skey]>
++0    accept(3, ..., ...) = 4
+
++0.0  < P. 1:1001(1000) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=1 ssn=1 dll=1000 nocs>
++0.0  >  . 1:1(0) ack 1001 win 264 <dss dack8=1001 nocs>
+
++0.2 < P. 1:1(0) ack 1 win 450 <mpcapable v1 flags[flag_h] key[skey,ckey]>
++0.0 > . 1:1(0) ack 1001 <add_address addr[saddr1] hmac=auto,dss dack8=1001 dll=0 nocs>
+
+// add another subflow.
++0.5 < addr[caddr1] > addr[saddr1] S 0:0(0) win 65535 <mss 1460,nop,wscale 7,mp_join_syn address_id=2 token=sha256_32(skey)>
++0.0 > S. 0:0(0) ack 1 <mss 1460,nop,wscale 8,mp_join_syn_ack address_id=0 sender_hmac=auto>
++0.0 < . 1:1(0) ack 1 win 256 <mp_join_ack sender_hmac=auto>
++0.0 > . 1:1(0) ack 1 win 256 <dss dack8=1001 nocs>
+
+// send more data at mptcp level.
++0.2  < P. 1:1002(1001) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=1001 ssn=1 dll=1001 nocs>
++0.0  >  . 1:1(0) ack 1002 win 264 <dss dack8=2002 dll=0 nocs>
+
+// fastclose on the 2nd subflow, but old sequence numbers.
++0.1  <  . 1:1(0) win 450 <mp_fastclose>
+
+// no effect expected.
++0.0  >  . 1:1(0) ack 1002 win 264 <dss dack8=2002 dll=0 nocs>
+
+// fastclose on the 2nd subflow, good sequence numbers.
++0.1  <  . 1002:1002(0) win 450 <mp_fastclose>
+
+// expect peer to reset both subflows now:
++0.0  > addr[saddr0] > addr[caddr0] R. 1:1(0) ack 1001 win 264
++0.0  > addr[saddr1] > addr[caddr1] R. 1:1(0) ack 1002 win 264
+
++0    read(4, ..., 2002) = 2001
++0    close(4) = 0

--- a/gtests/net/mptcp/fastclose/receive_fastclose_with_rst.pkt
+++ b/gtests/net/mptcp/fastclose/receive_fastclose_with_rst.pkt
@@ -1,0 +1,44 @@
+// connection initiated by packetdrill
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
++0    `../common/server.sh`
+
++0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
+
++0    bind(3, ..., ...) = 0
++0    listen(3, 1) = 0
++0.0    < addr[caddr0] > addr[saddr0] S 0:0(0) win 65535 <mss 1460,nop,wscale 7,mpcapable v1 flags[flag_h] nokey>
++0.0 > S. 0:0(0) ack 1 <mss 1460,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey]>
++0.0 < . 1:1(0) ack 1 win 256 <mpcapable v1 flags[flag_h] key[ckey=2,skey]>
++0    accept(3, ..., ...) = 4
+
++0.0  < P. 1:1001(1000) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=1 ssn=1 dll=1000 nocs>
++0.0  >  . 1:1(0) ack 1001 win 264 <dss dack8=1001 nocs>
+
+// send rst fastclose with a key that should not match.
++0     < R. 1001:1001(0) win 450 <mp_fastclose ckey=42 >
+
+// more data, but expect rst: the subflow is gone.
++1.0   < P. 1001:2001(1000) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=1001 ssn=1001 dll=1000 nocs>
++0.02  > R 1:1(0) ack 0 win 0
+
+// mp_join: supposed to work -- fastclose should have had no effect.
++0.1  < addr[caddr0] > addr[saddr0] S 0:0(0) win 65535 <mss 1460,nop,wscale 7,mp_join_syn address_id=0 token=sha256_32(skey)>
++0.0 > S. 0:0(0) ack 1 <mss 1460,nop,wscale 8,mp_join_syn_ack address_id=0 sender_hmac=auto>
++0.0 < . 1:1(0) ack 1 win 256 <mp_join_ack sender_hmac=auto>
++0.0 > . 1:1(0) ack 1 win 256 <add_address addr[saddr1] hmac=auto,dss dack8=1001 nocs>
+
+// more data, resend.  should work now.
++0.0  < P. 1:1001(1000) ack 1 win 450 <nop,nop,dss dack8=1 dsn8=1001 ssn=1 dll=1000 nocs>
++0.0  >  . 1:1(0) ack 1001 win 264 <dss dack8=2001 nocs>
+
+// send another rst fastclose, this time with matching key
++0.1  < R. 1001:1001(0) win 450 <mp_fastclose>
+
+// more data, expect a reset and win0 (no socket anymore)
++1.0  < P. 2001:3001(1000) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=2001 ssn=1001 dll=1000 nocs>
++0.01 > R 1:1(0) ack 0 win 0
+
++0    close(4) = 0

--- a/gtests/net/mptcp/fastclose/receive_fastclose_with_rst_multi.pkt
+++ b/gtests/net/mptcp/fastclose/receive_fastclose_with_rst_multi.pkt
@@ -1,0 +1,45 @@
+// connection initiated by packetdrill
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
++0    `../common/server.sh`
+
++0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
+
++0    bind(3, ..., ...) = 0
++0    listen(3, 1) = 0
++0.0    < addr[caddr0] > addr[saddr0] S 0:0(0) win 65535 <mss 1460,nop,wscale 7,mpcapable v1 flags[flag_h] nokey>
++0.0 > S. 0:0(0) ack 1 <mss 1460,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey]>
++0.0 < . 1:1(0) ack 1 win 256 <mpcapable v1 flags[flag_h] key[ckey=2,skey]>
++0    accept(3, ..., ...) = 4
+
++0.0  < P. 1:1001(1000) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=1 ssn=1 dll=1000 nocs>
++0.0  >  . 1:1(0) ack 1001 win 264 <dss dack8=1001 nocs>
+
++0.2 < P. 1:1(0) ack 1 win 450 <mpcapable v1 flags[flag_h] key[skey,ckey]>
++0.0 > . 1:1(0) ack 1001 <add_address addr[saddr1] hmac=auto,dss dack8=1001 dll=0 nocs>
+
+// add another subflow.
++0.5 < addr[caddr1] > addr[saddr1] S 0:0(0) win 65535 <mss 1460,nop,wscale 7,mp_join_syn address_id=2 token=sha256_32(skey)>
++0.0 > S. 0:0(0) ack 1 <mss 1460,nop,wscale 8,mp_join_syn_ack address_id=0 sender_hmac=auto>
++0.0 < . 1:1(0) ack 1 win 256 <mp_join_ack sender_hmac=auto>
++0.0 > . 1:1(0) ack 1 win 256 <dss dack8=1001 nocs>
+
+// send more data.
++0.2  < P. 1:1002(1001) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=1001 ssn=1 dll=1001 nocs>
++0    >  . 1:1(0) ack 1002 win 264 <dss dack8=2002 dll=0 nocs>
+
+// send rst fastclose.  Out of window, so it should have no effect.
++0.1  < R. 3001:3001(0) win 450 <mp_fastclose>
++0 `echo xxx`
++0    >  . 1:1(0) ack 1002 win 264 <dss dack8=2002 dll=0 nocs>
+
+// again. fastclose on the 2nd subflow.
++0.1  < R. 1002:1002(0) win 450 <mp_fastclose>
+
+// expect peer to reset the original flow now:
++0.0  > addr[saddr0] > addr[caddr0] R. 1:1(0) ack 1001 win 264
+
++0    read(4, ..., 2002) = 2001
++0    close(4) = 0


### PR DESCRIPTION
This adds four test cases for handling the mptcp fastclose option.
It covers four scenarios with a few variations:

1. fastclose_with_ack.pkt: single subflow. Test ACK with fastclose & bogus key has no effect.
 Test ACK with fastclose & expected key closes the mptcp connection, further data should result in a RST.

2. fastclose_with_rst.pkt: single subflow. Test RST with fastclose & bogus key closes the subflow but keeps mptcp socket around. Send a JOIN request after the RST, its expected to succeed. Then, another RST is sent, this time with correct fastclose.

2. fastclose_with_ack_multi.pkt: same as 1), but two subflows are created before the fastclose is sent on the new subflow.
   Its expected that the kernel sends a RST on both the original and the new subflow.

4. fastclose_with_rst_multi.pkt: same as 3), but the fastclose
   is carried on a RST segment.
   Its expected that the kernel sends a RST on the original subflow only (the 'new' subflow was closed on client side).