### PR TITLE
mptcp: add regression test for 0-len recvmsg()

### DIFF
--- a/gtests/net/mptcp/regressions/zero_len_recvmsg.pkt
+++ b/gtests/net/mptcp/regressions/zero_len_recvmsg.pkt
@@ -1,0 +1,24 @@
+// This test case cover the regression introduced by:
+// ea4ca586b16f ("mptcp: refine MPTCP-level ack scheduling")
+// connect() function, connection initiated by the kernel
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
+0.0   socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.1  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.1  fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
++0.1  fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+
+// Establish connection and swap to blocking mode
++0.0  connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
++0.01   > S 0:0(0) <mss 1460,sackOK,TS val 100 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
++0.01   < S. 0:0(0) ack 1 win 65535 <mss 1460,sackOK,TS val 700 ecr 100,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey=2] >
++0.01 > . 1:1(0) ack 1 <nop, nop, TS val 100 ecr 700,mpcapable v1 flags[flag_h] key[ckey,skey]>
++0.1 fcntl(3, F_SETFL, O_RDWR) = 0
+
+// do 0 len recvmsg with and without pending data
++0.1 recvmsg(3, {msg_name(...)=...,msg_iov(1)=[{..., 0}],msg_flags=0}, 0) = 0
++0.1   < .  1:201(200) ack 1 win 225 <dss dack8=1 dsn8=1 ssn=1 dll=200 nocs, nop, nop>
++0.01   > .  1:1(0) ack 201 <nop, nop, TS val 100 ecr 700, dss dack8=201 dll=0 nocs>
++0.1 recvmsg(3, {msg_name(...)=...,msg_iov(1)=[{..., 0}],msg_flags=0}, 0) = 0
+


### PR DESCRIPTION
The fix will be likely submitted soon by Eric.

Signed-off-by: Paolo Abeni <pabeni@redhat.com>