### PR TITLE
mptcp: add regression test for disconnect()

### DIFF
--- a/gtests/net/mptcp/regressions/unconnected_shutdown.pkt
+++ b/gtests/net/mptcp/regressions/unconnected_shutdown.pkt
@@ -1,0 +1,14 @@
+// This test case covers the regression fixed by ("mptcp: fix locking in mptcp_disconnect()")
+// shutdown a socket with connect pending, so that mptcp_disconnect()
+// is inoked
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
+0.0   socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0  fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
++0.0  fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+
++0.0 connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
++0.0   > S 0:0(0) <mss 1460,sackOK,TS val 100 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
+
++0.0 shutdown(3, SHUT_WR) = 0


### PR DESCRIPTION
This simply trigger the in-kernel mptcp disconnect
code path, so that we can have coverage for:

https://marc.info/?l=linux-netdev&m=161053335929207&w=2

Signed-off-by: Paolo Abeni <pabeni@redhat.com>