### PR TITLE
mptcp: ADD_ADDR are now sent sooner

### DIFF
--- a/gtests/net/mptcp/add_addr/add_addr_client.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr_client.pkt
@@ -25,5 +25,8 @@
 +0.0    < . 1:1(0) ack 101 win 256 <nop,nop,TS val 705 ecr 305,dss dack8=101 dll=0 nocs>
 +0.0    < . 1:1(0) ack 101 win 256 <nop,nop,TS val 705 ecr 305,add_address addr[saddr] hmac=auto,dss dack8=101 dll=0 nocs>
 
-+0.4 close(3) = 0
+// ADD_ADDR echo (without hmac)
++0.0    > . 101:101(0) ack 1 <nop, nop,TS val 494 ecr 700,add_address addr[saddr],dss dack4=1 dll=1 nocs>
+
++0.0 close(3) = 0
 +0.0   > . 101:101(0) ack 1 <nop, nop,TS val 494 ecr 700,dss dack4=1 dsn8=101 ssn=0 dll=1 nocs fin, nop, nop>

--- a/gtests/net/mptcp/add_addr/add_addr_server.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr_server.pkt
@@ -16,9 +16,14 @@
 +0.01   < . 1:1(0) ack 1 win 257 <mpcapable v1 flags[flag_h] key[ckey=2,skey]>
 +0    accept(3, ..., ...) = 4
 
+// ADD_ADDR is sent directly (>= 5.12), not after first data (< 5.12)
++0     > . 1:1(0) ack 1 <add_address addr[saddr] hmac=auto,dss dack4=1 ssn=1 dll=0 nocs>
+// TODO: support injecting ADD_ADDR echo
+//+0     < . 1:1(0) ack 1 win 257 <add_address addr[saddr],dss dack8=1 ssn=1 dll=0 nocs>
+
 // read and ack 1 data segment
 +1.0   < P. 1:1001(1000) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=1 ssn=1 dll=1000 nocs>
-+0     > . 1:1(0) ack 1001 <add_address addr[saddr] hmac=auto,dss dack8=1001 ssn=1 dll=0 nocs>
++0     > . 1:1(0) ack 1001 <dss dack8=1001 ssn=1 dll=0 nocs>
 +0.3  read(4, ..., 1000) = 1000
 
 +0    close(4) = 0

--- a/gtests/net/mptcp/fastclose/receive_fastclose_with_ack_multi_v4.pkt
+++ b/gtests/net/mptcp/fastclose/receive_fastclose_with_ack_multi_v4.pkt
@@ -14,11 +14,16 @@
 +0.0 < . 1:1(0) ack 1 win 256 <mpcapable v1 flags[flag_h] key[ckey=2,skey]>
 +0    accept(3, ..., ...) = 4
 
-+0.0  < P. 1:1001(1000) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=1 ssn=1 dll=1000 nocs>
+// add_addr
++0.0 > . 1:1(0) ack 1 <add_address addr[saddr1] hmac=auto,dss dack4=1 dll=0 nocs>
+// TODO: send echo bit
+// +0.0 < . 1:1(0) ack 1 win 256 <add_address addr[saddr1],dss dack8=1 dll=0 nocs>
+
++0.2  < P. 1:1001(1000) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=1 ssn=1 dll=1000 nocs>
 +0.0  >  . 1:1(0) ack 1001 <dss dack8=1001 nocs>
 
-+0.2 < P. 1:1(0) ack 1 win 450 <mpcapable v1 flags[flag_h] key[skey,ckey]>
-+0.0 > . 1:1(0) ack 1001 <add_address addr[saddr1] hmac=auto,dss dack8=1001 dll=0 nocs>
++0.2  < P. 1:1(0) ack 1 win 450 <mpcapable v1 flags[flag_h] key[skey,ckey]>
++0.0  >  . 1:1(0) ack 1001 <dss dack8=1001 nocs>
 
 // add another subflow.
 +0.5 < addr[caddr1] > addr[saddr1] S 0:0(0) win 65535 <mss 1460,nop,wscale 7,mp_join_syn address_id=2 token=sha256_32(skey)>

--- a/gtests/net/mptcp/fastclose/receive_fastclose_with_rst_multi_v4.pkt
+++ b/gtests/net/mptcp/fastclose/receive_fastclose_with_rst_multi_v4.pkt
@@ -14,11 +14,16 @@
 +0.0 < . 1:1(0) ack 1 win 256 <mpcapable v1 flags[flag_h] key[ckey=2,skey]>
 +0    accept(3, ..., ...) = 4
 
-+0.0  < P. 1:1001(1000) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=1 ssn=1 dll=1000 nocs>
+// add_addr
++0.0 > . 1:1(0) ack 1 <add_address addr[saddr1] hmac=auto,dss dack4=1 dll=0 nocs>
+// TODO: send echo bit
+// +0.0 < . 1:1(0) ack 1 win 256 <add_address addr[saddr1],dss dack8=1 dll=0 nocs>
+
++0.2  < P. 1:1001(1000) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=1 ssn=1 dll=1000 nocs>
 +0.0  >  . 1:1(0) ack 1001 <dss dack8=1001 nocs>
 
-+0.2 < P. 1:1(0) ack 1 win 450 <mpcapable v1 flags[flag_h] key[skey,ckey]>
-+0.0 > . 1:1(0) ack 1001 <add_address addr[saddr1] hmac=auto,dss dack8=1001 dll=0 nocs>
++0.2  < P. 1:1(0) ack 1 win 450 <mpcapable v1 flags[flag_h] key[skey,ckey]>
++0.0  >  . 1:1(0) ack 1001 <dss dack8=1001 nocs>
 
 // add another subflow.
 +0.5 < addr[caddr1] > addr[saddr1] S 0:0(0) win 65535 <mss 1460,nop,wscale 7,mp_join_syn address_id=2 token=sha256_32(skey)>

--- a/gtests/net/mptcp/mp_join/mp_join_client_v4.pkt
+++ b/gtests/net/mptcp/mp_join/mp_join_client_v4.pkt
@@ -20,11 +20,13 @@
 +0.0 < . 1:1(0) ack 3 win 256 <nop,nop,TS val 4074418293 ecr 4074418292,add_address addr[saddr1] hmac=auto,dss dack8=3 dll=0 nocs>
 
 +0.0 > > addr[saddr1] S 0:0(0) <mss 1460,sackOK,TS val 448955294 ecr 0,nop,wscale 8,mp_join_syn address_id=0 token=sha256_32(skey)>
++0.0 > > addr[saddr0] . 3:3(0) ack 1 <nop, nop, TS val 448955294 ecr 448955294, add_address addr[saddr1], dss dack4=1 nocs>
+
 +0.0 < S. 0:0(0) ack 1 win 65535 <mss 1460,sackOK,TS val 448955294 ecr 448955294,nop,wscale 8,mp_join_syn_ack address_id=1 sender_hmac=auto>
 +0.0 > . 1:1(0) ack 1 <nop,nop,TS val 448955294 ecr 448955294,mp_join_ack sender_hmac=auto>
 +0.0 < . 1:1(0) ack 1 win 256 <nop,nop,TS val 448955294 ecr 448955294, dss dack8=3 nocs>
 +1.0 < . 1:101(100) ack 1 win 256 <TS val 448955294 ecr 448955294, dss dack8=3 dsn8=1 ssn=1 dll=100 nocs>
-+0.0 > . 1:1(0) ack 101 <nop, nop, TS val 448955294 ecr 448955294, add_address addr[saddr1], dss dack8=101 nocs>
++0.0 > . 1:1(0) ack 101 <nop, nop, TS val 448955294 ecr 448955294, dss dack8=101 nocs>
 +0.0 read (3, ..., 100) = 100
 +0.1 close(3) = 0
 +0.0 > addr[caddr0] > addr[saddr0] . 3:3(0) ack 1 <nop,nop,TS val 4074418292 ecr 4074418293,dss dack8=101 dsn8=3 ssn=0 dll=1 nocs fin,nop,nop>

--- a/gtests/net/mptcp/mp_join/mp_join_server_v4.pkt
+++ b/gtests/net/mptcp/mp_join/mp_join_server_v4.pkt
@@ -16,8 +16,15 @@
 +0.0 < . 1:1(0) ack 1 win 256 <nop,nop,TS val 4074410674 ecr 4074410674,mpcapable v1 flags[flag_h] key[ckey=2,skey]>
 +0    accept(3, ..., ...) = 4
 
-+1.0 < P. 1:3(2) ack 1 win 256 <nop,nop,TS val 4074418292 ecr 4074410674,mpcapable v1 flags[flag_h] key[skey,ckey] mpcdatalen 2,nop,nop>
-+0.0 > . 1:1(0) ack 3 <nop,nop,TS val 4074418293 ecr 4074418292,add_address addr[saddr1] hmac=auto,dss dack8=3 dll=0 nocs>
+// add_addr
++0.0 > . 1:1(0) ack 1 <nop,nop,TS val 4074418293 ecr 4074418292,add_address addr[saddr1] hmac=auto,dss dack4=1 dll=0 nocs>
+// TODO: send echo bit
+// +0.0 > . 1:1(0) ack 1 <nop,nop,TS val 4074418293 ecr 4074418292,add_address addr[saddr1],dss dack8=1 dll=0 nocs>
+
++0.2 < P. 1:3(2) ack 1 win 256 <nop,nop,TS val 4074418292 ecr 4074410674,mpcapable v1 flags[flag_h] key[skey,ckey] mpcdatalen 2,nop,nop>
+// MP_CAPABLE carrying data are acked with 64-bit, safer not knowing if the
+// sender will use a DSN on 64-bit or 32-bit. Later we can use the lower 32 bits
++0.0 > . 1:1(0) ack 3 <nop,nop,TS val 4074418293 ecr 4074418292,dss dack8=3 dll=0 nocs>
 
 // create subflow
 +0.0 < addr[caddr1] > addr[saddr1] S 0:0(0) win 65535 <mss 1460,sackOK,TS val 448955294 ecr 0,nop,wscale 8,mp_join_syn backup=1 address_id=2 token=sha256_32(skey)>


### PR DESCRIPTION
A recent modification of the kernel changes the way ADD_ADDR are sent.
See: https://github.com/multipath-tcp/mptcp_net-next/issues/139

In consequences, we have to adapt our tests to have these ADD_ADDR sent
earlier, ASAP in fact. We now make sure ADD_ADDR and ADD_ADDR echo are
properly sent before injecting MP_JOIN SYN and SYN+ACK or sending data.

Closes: https://github.com/multipath-tcp/mptcp_net-next/issues/144
Signed-off-by: Matthieu Baerts <matthieu.baerts@tessares.net>