### PR TITLE
mptcp: remove receive window specification from kernel pkt

### DIFF
--- a/gtests/net/mptcp/fastclose/receive_fastclose_with_ack.pkt
+++ b/gtests/net/mptcp/fastclose/receive_fastclose_with_ack.pkt
@@ -13,19 +13,19 @@
 +0    accept(3, ..., ...) = 4
 
 +0.0  < P. 1:1001(1000) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=1 ssn=1 dll=1000 nocs>
-+0.0  >  . 1:1(0) ack 1001 win 264 <dss dack8=1001 nocs>
++0.0  >  . 1:1(0) ack 1001 <dss dack8=1001 nocs>
 
 // send ack fastclose with a key that should not match.
 +0    < . 1001:1001(0) win 450 <mp_fastclose ckey=42 >
 
 // more data, expect ack
 +1.0  < P. 1001:2001(1000) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=1001 ssn=1001 dll=1000 nocs>
-+0.0  > . 1:1(0) ack 2001 win 272 <dss dack8=2001 nocs>
++0.0  > . 1:1(0) ack 2001 <dss dack8=2001 nocs>
 
 // send another ack fastclose, this time with matching key
 +0.1      < . 2001:2001(0) win 450 <mp_fastclose>
 // expect peer to reset all subflows now:
-+0.01 > R. 1:1(0) ack 2001 win 272
++0.01 > R. 1:1(0) ack 2001
 
 // more data, expect a reset and win0 (no socket anymore)
 +1.0  < P. 2001:3001(1000) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=2001 ssn=2001 dll=1000 nocs>

--- a/gtests/net/mptcp/fastclose/receive_fastclose_with_ack_multi_v4.pkt
+++ b/gtests/net/mptcp/fastclose/receive_fastclose_with_ack_multi_v4.pkt
@@ -15,7 +15,7 @@
 +0    accept(3, ..., ...) = 4
 
 +0.0  < P. 1:1001(1000) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=1 ssn=1 dll=1000 nocs>
-+0.0  >  . 1:1(0) ack 1001 win 264 <dss dack8=1001 nocs>
++0.0  >  . 1:1(0) ack 1001 <dss dack8=1001 nocs>
 
 +0.2 < P. 1:1(0) ack 1 win 450 <mpcapable v1 flags[flag_h] key[skey,ckey]>
 +0.0 > . 1:1(0) ack 1001 <add_address addr[saddr1] hmac=auto,dss dack8=1001 dll=0 nocs>
@@ -24,24 +24,24 @@
 +0.5 < addr[caddr1] > addr[saddr1] S 0:0(0) win 65535 <mss 1460,nop,wscale 7,mp_join_syn address_id=2 token=sha256_32(skey)>
 +0.0 > S. 0:0(0) ack 1 <mss 1460,nop,wscale 8,mp_join_syn_ack address_id=0 sender_hmac=auto>
 +0.0 < . 1:1(0) ack 1 win 256 <mp_join_ack sender_hmac=auto>
-+0.0 > . 1:1(0) ack 1 win 256 <dss dack8=1001 nocs>
++0.0 > . 1:1(0) ack 1 <dss dack8=1001 nocs>
 
 // send more data at mptcp level.
 +0.2  < P. 1:1002(1001) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=1001 ssn=1 dll=1001 nocs>
-+0.0  >  . 1:1(0) ack 1002 win 264 <dss dack8=2002 dll=0 nocs>
++0.0  >  . 1:1(0) ack 1002 <dss dack8=2002 dll=0 nocs>
 
 // fastclose on the 2nd subflow, but old sequence numbers.
 +0.1  <  . 1:1(0) win 450 <mp_fastclose>
 
 // no effect expected.
-+0.0  >  . 1:1(0) ack 1002 win 264 <dss dack8=2002 dll=0 nocs>
++0.0  >  . 1:1(0) ack 1002 <dss dack8=2002 dll=0 nocs>
 
 // fastclose on the 2nd subflow, good sequence numbers.
 +0.1  <  . 1002:1002(0) win 450 <mp_fastclose>
 
 // expect peer to reset both subflows now:
-+0.0  > addr[saddr0] > addr[caddr0] R. 1:1(0) ack 1001 win 264
-+0.0  > addr[saddr1] > addr[caddr1] R. 1:1(0) ack 1002 win 264
++0.0  > addr[saddr0] > addr[caddr0] R. 1:1(0) ack 1001
++0.0  > addr[saddr1] > addr[caddr1] R. 1:1(0) ack 1002
 
 +0    read(4, ..., 2002) = 2001
 +0    close(4) = 0

--- a/gtests/net/mptcp/fastclose/receive_fastclose_with_rst_multi_v4.pkt
+++ b/gtests/net/mptcp/fastclose/receive_fastclose_with_rst_multi_v4.pkt
@@ -15,7 +15,7 @@
 +0    accept(3, ..., ...) = 4
 
 +0.0  < P. 1:1001(1000) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=1 ssn=1 dll=1000 nocs>
-+0.0  >  . 1:1(0) ack 1001 win 264 <dss dack8=1001 nocs>
++0.0  >  . 1:1(0) ack 1001 <dss dack8=1001 nocs>
 
 +0.2 < P. 1:1(0) ack 1 win 450 <mpcapable v1 flags[flag_h] key[skey,ckey]>
 +0.0 > . 1:1(0) ack 1001 <add_address addr[saddr1] hmac=auto,dss dack8=1001 dll=0 nocs>
@@ -24,21 +24,21 @@
 +0.5 < addr[caddr1] > addr[saddr1] S 0:0(0) win 65535 <mss 1460,nop,wscale 7,mp_join_syn address_id=2 token=sha256_32(skey)>
 +0.0 > S. 0:0(0) ack 1 <mss 1460,nop,wscale 8,mp_join_syn_ack address_id=0 sender_hmac=auto>
 +0.0 < . 1:1(0) ack 1 win 256 <mp_join_ack sender_hmac=auto>
-+0.0 > . 1:1(0) ack 1 win 256 <dss dack8=1001 nocs>
++0.0 > . 1:1(0) ack 1 <dss dack8=1001 nocs>
 
 // send more data.
 +0.2  < P. 1:1002(1001) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=1001 ssn=1 dll=1001 nocs>
-+0    >  . 1:1(0) ack 1002 win 264 <dss dack8=2002 dll=0 nocs>
++0    >  . 1:1(0) ack 1002 <dss dack8=2002 dll=0 nocs>
 
 // send rst fastclose.  Out of window, so it should have no effect.
 +0.1  < R. 3001:3001(0) win 450 <mp_fastclose>
-+0    >  . 1:1(0) ack 1002 win 264 <dss dack8=2002 dll=0 nocs>
++0    >  . 1:1(0) ack 1002 <dss dack8=2002 dll=0 nocs>
 
 // again. fastclose on the 2nd subflow.
 +0.1  < R. 1002:1002(0) win 450 <mp_fastclose>
 
 // expect peer to reset the original flow now:
-+0.0  > addr[saddr0] > addr[caddr0] R. 1:1(0) ack 1001 win 264
++0.0  > addr[saddr0] > addr[caddr0] R. 1:1(0) ack 1001
 
 +0    read(4, ..., 2002) = 2001
 +0    close(4) = 0

--- a/gtests/net/mptcp/fastclose/receive_fastclose_with_rst_v4.pkt
+++ b/gtests/net/mptcp/fastclose/receive_fastclose_with_rst_v4.pkt
@@ -15,7 +15,7 @@
 +0    accept(3, ..., ...) = 4
 
 +0.0  < P. 1:1001(1000) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=1 ssn=1 dll=1000 nocs>
-+0.0  >  . 1:1(0) ack 1001 win 264 <dss dack8=1001 nocs>
++0.0  >  . 1:1(0) ack 1001 <dss dack8=1001 nocs>
 
 // send rst fastclose with a key that should not match.
 +0     < R. 1001:1001(0) win 450 <mp_fastclose ckey=42 >
@@ -28,11 +28,11 @@
 +0.1  < addr[caddr0] > addr[saddr0] S 0:0(0) win 65535 <mss 1460,nop,wscale 7,mp_join_syn address_id=0 token=sha256_32(skey)>
 +0.0 > S. 0:0(0) ack 1 <mss 1460,nop,wscale 8,mp_join_syn_ack address_id=0 sender_hmac=auto>
 +0.0 < . 1:1(0) ack 1 win 256 <mp_join_ack sender_hmac=auto>
-+0.0 > . 1:1(0) ack 1 win 256 <add_address addr[saddr1] hmac=auto,dss dack8=1001 nocs>
++0.0 > . 1:1(0) ack 1 <add_address addr[saddr1] hmac=auto,dss dack8=1001 nocs>
 
 // more data, resend.  should work now.
 +0.0  < P. 1:1001(1000) ack 1 win 450 <nop,nop,dss dack8=1 dsn8=1001 ssn=1 dll=1000 nocs>
-+0.0  >  . 1:1(0) ack 1001 win 264 <dss dack8=2001 nocs>
++0.0  >  . 1:1(0) ack 1001 <dss dack8=2001 nocs>
 
 // send another rst fastclose, this time with matching key
 +0.1  < R. 1001:1001(0) win 450 <mp_fastclose>

--- a/gtests/net/mptcp/mp_join/mp_join_client_v4.pkt
+++ b/gtests/net/mptcp/mp_join/mp_join_client_v4.pkt
@@ -24,7 +24,7 @@
 +0.0 > . 1:1(0) ack 1 <nop,nop,TS val 448955294 ecr 448955294,mp_join_ack sender_hmac=auto>
 +0.0 < . 1:1(0) ack 1 win 256 <nop,nop,TS val 448955294 ecr 448955294, dss dack8=3 nocs>
 +1.0 < . 1:101(100) ack 1 win 256 <TS val 448955294 ecr 448955294, dss dack8=3 dsn8=1 ssn=1 dll=100 nocs>
-+0.0 > . 1:1(0) ack 101 win 256 <nop, nop, TS val 448955294 ecr 448955294, add_address addr[saddr1], dss dack8=101 nocs>
++0.0 > . 1:1(0) ack 101 <nop, nop, TS val 448955294 ecr 448955294, add_address addr[saddr1], dss dack8=101 nocs>
 +0.0 read (3, ..., 100) = 100
 +0.1 close(3) = 0
 +0.0 > addr[caddr0] > addr[saddr0] . 3:3(0) ack 1 <nop,nop,TS val 4074418292 ecr 4074418293,dss dack8=101 dsn8=3 ssn=0 dll=1 nocs fin,nop,nop>


### PR DESCRIPTION
automated with:

    find gtests/net/mptcp/ -name *pkt -exec sed -i -e 's/\(^.\{1,6\}>.*\) win [1-9][0-9]*/\1/' \{\} \

Needed to be auto-tune independed