### PR TITLE
mptcp: add test case for full data_fin handshake

### DIFF
--- a/gtests/net/mptcp/dss/dss_fin_server.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_server.pkt
@@ -1,0 +1,26 @@
+// Test the full data fin handshake, server side
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
++0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
+
++0    bind(3, ..., ...) = 0
++0    listen(3, 1) = 0
++0      < S 0:0(0) win 32792 <mss 1000,sackOK,nop,nop,nop,wscale 7,mpcapable v1 flags[flag_h] nokey>
++0      > S. 0:0(0) ack 1 <mss 1460,nop,nop,sackOK,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey] >
++0.01   < . 1:1(0) ack 1 win 257 <mpcapable v1 flags[flag_h] key[ckey=2,skey] >
++0    accept(3, ..., ...) = 4
+
+// the client shutdown its side
++0.0   < P. 1:1(0) ack 1 win 450 <dss dack4=1 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
++0.0   > . 1:1(0) ack 1 <dss dack4=2 nocs>
++0.0   < F. 1:1(0) ack 1 win 450 <dss dack4=1 nocs>
++0.0   > . 1:1(0) ack 2 <dss dack4=2 nocs>
+
+// server shutdown
++0   close(4) = 0
++0     > . 1:1(0) ack 2 <dss dack4=2 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
++0     < . 2:2(0) ack 1 win 450 <dss dack4=2 nocs>
++0     > F. 1:1(0) ack 2 <dss dack4=2 nocs>
++0     < . 2:2(0) ack 2 win 450 <dss dack4=2 nocs>


### PR DESCRIPTION
The current cases only cover half close. This one covers
the server side, both ways.

Signed-off-by: Paolo Abeni <pabeni@redhat.com>