### PR TITLE
mptcp: add a new 'syscalls' subcategory

### DIFF
--- a/gtests/net/mptcp/syscalls/connect_poll.pkt
+++ b/gtests/net/mptcp/syscalls/connect_poll.pkt
@@ -1,0 +1,21 @@
+// connect() function, connection initiated by the kernel
+// ensure we get poll() wake-ups when connect() completes
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
+0.0   socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0  fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
++0.0  fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+
+// Establish connection and verify we get timely poll wakeups
+
++0.0  connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
++0.0   > S 0:0(0) <mss 1460,sackOK,TS val 100 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
++0.02  < S. 0:0(0) ack 1 win 65535 <mss 1460,sackOK,TS val 700 ecr 100,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey=2] >
++0.0   > . 1:1(0) ack 1 <nop,nop,TS val 100 ecr 700,mpcapable v1 flags[flag_h] key[ckey,skey] >
+
++0...0.020 poll([{fd=3,
+		events=POLLOUT,
+		revents=POLLOUT}], 1, 1000) = 1
++0.200 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0

--- a/gtests/net/mptcp/syscalls/connect_reset_poll.pkt
+++ b/gtests/net/mptcp/syscalls/connect_reset_poll.pkt
@@ -1,0 +1,21 @@
+// connect() function, connection initiated by the kernel
+// test the connect()/poll() error path
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
+0.0   socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0  fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
++0.0  fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+
+// connection fails and verify that the error is properly
+// reported by poll()
+
++0.0  connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
++0.0   > S 0:0(0) <mss 1460,sackOK,TS val 100 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
++0.02  < R. 0:0(0) ack 1 win 65535 <nop,nop,TS val 700 ecr 100>
+
++0...0.020 poll([{fd=3,
+		events=POLLOUT,
+		revents=POLLOUT|POLLERR|POLLHUP}], 1, 1000) = 1
++0.200 getsockopt(3, SOL_SOCKET, SO_ERROR, [ECONNREFUSED], [4]) = 0

--- a/gtests/net/mptcp/syscalls/connect_reset_send.pkt
+++ b/gtests/net/mptcp/syscalls/connect_reset_send.pkt
@@ -1,0 +1,23 @@
+// connect() function, connection initiated by the kernel
+// test the connect()/send() error path
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
+0.0   socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0  fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
++0.0  fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+
+// Establish connection and verify that blocking send()
+// fails as soon as the connection attempt fails
+
++0.0  connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
++0.0   > S 0:0(0) <mss 1460,sackOK,TS val 100 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
+
+
++0.0  send(3, ..., 400, 0) = -1  EAGAIN (Resource temporarily unavailable)
++0.0  fcntl(3, F_SETFL, O_RDWR) = 0
+
++0.02  < R. 0:0(0) ack 1 win 65535 <nop,nop,TS val 700 ecr 100>
+
++0...0.020 send(3, ..., 400, 0) = -1 ECONNREFUSED (Software caused connection abort)

--- a/gtests/net/mptcp/syscalls/connect_send.pkt
+++ b/gtests/net/mptcp/syscalls/connect_send.pkt
@@ -1,0 +1,24 @@
+// connect() function, connection initiated by the kernel
+// ensure we get send() wake-up events correctly
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
+0.0   socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0  fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
++0.0  fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+
+// Establish connection and verify blocking write will be woken-up by
+// MPC completion
+
++0.0  connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
++0.0   > S 0:0(0) <mss 1460,sackOK,TS val 100 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
+
+
++0.0  send(3, ..., 400, 0) = -1  EAGAIN (Resource temporarily unavailable)
++0.0  fcntl(3, F_SETFL, O_RDWR) = 0
+
++0.02  < S. 0:0(0) ack 1 win 65535 <mss 1460,sackOK,TS val 700 ecr 100,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey=2] >
++0.0   > . 1:1(0) ack 1 <nop,nop,TS val 100 ecr 700,mpcapable v1 flags[flag_h] key[ckey,skey] >
+
++0...0.020 send(3, ..., 400, 0) = 400


### PR DESCRIPTION
It contains tests for some specific/relevant syscalls
sequence.

This bunch contains some connect related tests, both
for successful and failed connection attempt.

*reset* tests will fail without 'mptcp: handle socket errors'
patches on the kernels side.

Signed-off-by: Paolo Abeni <pabeni@redhat.com>