### PR TITLE
MP_PRIO smoketest

### DIFF
--- a/gtests/net/mptcp/mp_prio/mp_prio_server_v4.pkt
+++ b/gtests/net/mptcp/mp_prio/mp_prio_server_v4.pkt
@@ -1,0 +1,59 @@
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
++0    `../common/server.sh`
+
++0.0  socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0  fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
++0.0  fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+
++0    bind(3, ..., ...) = 0
++0    listen(3, 1) = 0
+
++0.0 < addr[caddr0] > addr[saddr0] S 0:0(0) win 65535 <mss 1460,sackOK,TS val 4074410674 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
++0.0 > S. 0:0(0) ack 1 <mss 1460,sackOK,TS val 4074410674 ecr 4074410674,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey]>
++0.0 < . 1:1(0) ack 1 win 256 <nop,nop,TS val 4074410674 ecr 4074410674,mpcapable v1 flags[flag_h] key[ckey=2,skey]>
++0    accept(3, ..., ...) = 4
+
+// add_addr
++0.0 > . 1:1(0) ack 1 <nop,nop,TS val 4074418293 ecr 4074418292,add_address addr[saddr1] hmac=auto,dss dack4=1 dll=0 nocs>
+// TODO: send echo bit
+// +0.0 > . 1:1(0) ack 1 <nop,nop,TS val 4074418293 ecr 4074418292,add_address addr[saddr1],dss dack8=1 dll=0 nocs>
+
++0.2 < P. 1:3(2) ack 1 win 256 <nop,nop,TS val 4074418292 ecr 4074410674,mpcapable v1 flags[flag_h] key[skey,ckey] mpcdatalen 2,nop,nop>
+// MP_CAPABLE carrying data are acked with 64-bit, safer not knowing if the
+// sender will use a DSN on 64-bit or 32-bit. Later we can use the lower 32 bits
++0.0 > . 1:1(0) ack 3 <nop,nop,TS val 4074418293 ecr 4074418292,dss dack8=3 dll=0 nocs>
++0.0 read(4, ..., 2) = 2
+
+// more inbound data and MP_PRIO to flip active -> backup
++0.0 < P. 3:5(2) ack 1 win 256 <dss dack8=1 dsn4=3 ssn=3 dll=2 nocs, mp_prio backup=1, nop, nop, nop>
++0.0 > . 1:1(0) ack 5 <nop,nop,TS val 4074418293 ecr 4074418292,dss dack4=5 nocs>
++0.0 read(4, ..., 2) = 2
+
+// create subflow
++0.0 < addr[caddr1] > addr[saddr1] S 0:0(0) win 65535 <mss 1460,sackOK,TS val 448955294 ecr 0,nop,wscale 8,mp_join_syn backup=1 address_id=2 token=sha256_32(skey)>
++0.0 > S. 0:0(0) ack 1 <mss 1460,sackOK,TS val 448955294 ecr 448955294,nop,wscale 8,mp_join_syn_ack backup=1 address_id=0 sender_hmac=auto>
++0.0 < . 1:1(0) ack 1 win 256 <nop,nop,TS val 448955294 ecr 448955294,mp_join_ack sender_hmac=auto>
++0.0 > . 1:1(0) ack 1 <nop,nop,TS val 448955294 ecr 448955294,dss dack4=5 nocs>
+
+// more inbound data and MP_PRIO to flip backup -> active
++0.0 < P. 1:11(10) ack 1 win 256 <dss dack8=1 dsn4=5 ssn=1 dll=10 nocs, mp_prio backup=0, nop, nop, nop>
++0.0 > . 1:1(0) ack 11 <nop,nop,TS val 448955294 ecr 448955294,dss dack4=15 nocs>
++0.0 read(4, ..., 10) = 10
+
+// write() should now go through joined subflow
++0.0 write(4, ..., 100) = 100
++0.0 > addr[saddr1] > addr[caddr1] P. 1:101(100) ack 11 <nop,nop,TS val 448955294 ecr 448955294,dss dack4=15 dsn8=1 ssn=1 dll=100 nocs, nop, nop>
+// silently refuse v0 mp_prio
++0.0 < addr[caddr1] > addr[saddr1] . 11:11(0) ack 101 win 256 <dss dack8=101 nocs, mp_prio backup=1 address_id=1>
++0.0 write(4, ..., 100) = 100
++0.0 > addr[saddr1] > addr[caddr1] P. 101:201(100) ack 11 <nop,nop,TS val 448955294 ecr 448955294,dss dack4=15 dsn8=101 ssn=101 dll=100 nocs, nop, nop>
++0.0 < addr[caddr1] > addr[saddr1] . 11:11(0) ack 201 win 256 <dss dack8=201 nocs>
+
+// client sends DATA-FIN, subflows ack it
++0.0 < addr[caddr1] > addr[saddr1] . 11:11(0) ack 201 win 256 <dss dack8=201 dsn8=15 dll=1 nocs fin, nop, nop>
++0.0 > addr[saddr0] > addr[caddr0] . 1:1(0) ack 5 <nop,nop,TS val 448955294 ecr 448955294,dss dack4=16 nocs>
++0.0 > addr[saddr1] > addr[caddr1] . 201:201(0) ack 11 <nop,nop,TS val 448955294 ecr 448955294,dss dack4=16 nocs>
+


### PR DESCRIPTION
basic functional test that uses inbound MP_PRIO to flip the 'backup' flag
in the MP_JOIN server scenario.

Link: https://github.com/multipath-tcp/mptcp_net-next/issues/51
Signed-off-by: Davide Caratti <dcaratti@redhat.com>