### PR TITLE
mptcp: define a common code style for the scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,25 @@ chmod u+x checkpatch.pl
 ```
 git send-email --to packetdrill@googlegroups.com 00*.patch
 ```
+
+# MPTCP version
+
+## Code-style
+
+The idea is to easily spot options, direction, by increasing spaces and aligning groups.
+
+Code style for the packet traces:
+* (minimum) 2 spaces between each section: times, syscalls, directions, flags, ACK, Win, options
+* Align all syscalls together: two spaces after the larger time
+* Align TCP flags (S, ., P, F, R)
+* It's OK to align per block, e.g. align for the initiation of the connection but it can be different for the options during a transfer
+* Spaces after commas in TCP options
+* Blank lines between blocks
+
+## Guidelines
+
+* Add load of comments: what the next block is doing and the **reason**
+* No need to put a TCP window for outbound packets (except for 0) to allow env with different auto-tuning settings
+```
+find gtests/net/mptcp/ -name *pkt -exec sed -i -e 's/\(^\S\+\s\+>.*\) win [1-9][0-9]*/\1/' \{\} \;
+```

--- a/gtests/net/mptcp/add_addr/add_addr_client.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr_client.pkt
@@ -2,31 +2,32 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-+0   `../common/client.sh`
++0     `../common/client.sh`
 
-+0.0  socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
-+0.0  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
-+0.0  fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
-+0.0  fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
++0.0   socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0   setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0   fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
++0.0   fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
 
-+0.0  connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
-+0.0    > S 0:0(0) <mss 1460,sackOK,TS val 100 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
-+0.0    < S. 0:0(0) ack 1 win 65535 <mss 1460,sackOK,TS val 700 ecr 100,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey=2]>
-+0.0    > . 1:1(0) ack 1 <nop,nop,TS val 100 ecr 700,mpcapable v1 flags[flag_h] key[ckey,skey]>
-+0.200 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
-+0.205 fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
++0.0   connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
++0.0      >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++0.0      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
-+0.01 write(3,..., 100) = 100
-+0.0    > P. 1:101(100) ack 1 <nop,nop,TS val 305 ecr 700,mpcapable v1 flags[flag_h] key[ckey,skey] mpcdatalen 100,nop,nop>
++0.200  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.205  fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
+
++0.01   write(3, ..., 100) = 100
++0.0      >  P.  1:101(100)  ack 1         <nop, nop, TS val 305 ecr 700, mpcapable v1 flags[flag_h] key[ckey, skey] mpcdatalen 100, nop, nop>
 
 // explicit ACK then ADD_ADDR: on some slow env, injecting ADD_ADDR can take
 // time, causing the host to retransmit its last data packet. Here we ensure
 // this previous packet is acked then we can send the ADD_ADDR
-+0.0    < . 1:1(0) ack 101 win 256 <nop,nop,TS val 705 ecr 305,dss dack8=101 dll=0 nocs>
-+0.0    < . 1:1(0) ack 101 win 256 <nop,nop,TS val 705 ecr 305,add_address addr[saddr] hmac=auto,dss dack8=101 dll=0 nocs>
++0.0      <   .  1:1(0)  ack 101  win 256  <nop, nop, TS val 705 ecr 305,                                    dss dack8=101 dll=0 nocs>
++0.0      <   .  1:1(0)  ack 101  win 256  <nop, nop, TS val 705 ecr 305, add_address addr[saddr] hmac=auto, dss dack8=101 dll=0 nocs>
 
 // ADD_ADDR echo (without hmac)
-+0.0    > . 101:101(0) ack 1 <nop, nop,TS val 494 ecr 700,add_address addr[saddr],dss dack4=1 dll=1 nocs>
++0.0      >   .  101:101(0)  ack 1         <nop, nop, TS val 494 ecr 700, add_address addr[saddr]          , dss dack4=1   dll=1 nocs>
 
 +0.0 close(3) = 0
-+0.0   > . 101:101(0) ack 1 <nop, nop,TS val 494 ecr 700,dss dack4=1 dsn8=101 ssn=0 dll=1 nocs fin, nop, nop>
++0.0      >   .  101:101(0)  ack 1         <nop, nop, TS val 494 ecr 700,                                    dss dack4=1   dsn8=101 ssn=0 dll=1 nocs fin, nop, nop>

--- a/gtests/net/mptcp/add_addr/add_addr_server.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr_server.pkt
@@ -3,28 +3,28 @@
 `../common/defaults.sh`
 
 // TODO(malsbat):
-+0    `ip mptcp endpoint flush`
-+0    `ip mptcp endpoint add 192.168.122.83 signal`
++0     `ip mptcp endpoint flush`
++0     `ip mptcp endpoint add 192.168.122.83 signal`
 
-+0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
-+0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
 
-+0    bind(3, ..., ...) = 0
-+0    listen(3, 1) = 0
-+0      < S 0:0(0) win 32792 <mss 1460,sackOK,nop,nop,nop,wscale 7,mpcapable v1 flags[flag_h] nokey>
-+0      > S. 0:0(0) ack 1 <mss 1460,nop,nop,sackOK,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey] >
-+0.01   < . 1:1(0) ack 1 win 257 <mpcapable v1 flags[flag_h] key[ckey=2,skey]>
-+0    accept(3, ..., ...) = 4
++0     bind(3, ..., ...) = 0
++0     listen(3, 1) = 0
++0       <  S   0:0(0)         win 32792  <mss 1460, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.01    <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0     accept(3, ..., ...) = 4
 
 // ADD_ADDR is sent directly (>= 5.12), not after first data (< 5.12)
-+0     > . 1:1(0) ack 1 <add_address addr[saddr] hmac=auto,dss dack4=1 ssn=1 dll=0 nocs>
++0       >   .  1:1(0)        ack 1              <add_address addr[saddr] hmac=auto, dss dack4=1           ssn=1 dll=0 nocs>
 // TODO: support injecting ADD_ADDR echo
-//+0     < . 1:1(0) ack 1 win 257 <add_address addr[saddr],dss dack8=1 ssn=1 dll=0 nocs>
+//+0     <   .  1:1(0)        ack 1     win 257  <add_address addr[saddr],           dss dack8=1           ssn=1 dll=0 nocs>
 
 // read and ack 1 data segment
-+1.0   < P. 1:1001(1000) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=1 ssn=1 dll=1000 nocs>
-+0     > . 1:1(0) ack 1001 <dss dack8=1001 ssn=1 dll=0 nocs>
-+0.3  read(4, ..., 1000) = 1000
++1.0     <  P.  1:1001(1000)  ack 1     win 450  <nop, nop,                          dss dack8=1    dsn8=1 ssn=1 dll=1000 nocs>
++0       >   .  1:1(0)        ack 1001                                              <dss dack8=1001        ssn=1 dll=0 nocs>
++0.3   read(4, ..., 1000) = 1000
 
-+0    close(4) = 0
-+0     > . 1:1(0) ack 1001 <dss dack8=1001 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
++0     close(4) = 0
++0       >   .  1:1(0)        ack 1001                                              <dss dack8=1001 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>

--- a/gtests/net/mptcp/dss/dss_fin_server.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_server.pkt
@@ -2,25 +2,25 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-+0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
-+0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
 
-+0    bind(3, ..., ...) = 0
-+0    listen(3, 1) = 0
-+0      < S 0:0(0) win 32792 <mss 1000,sackOK,nop,nop,nop,wscale 7,mpcapable v1 flags[flag_h] nokey>
-+0      > S. 0:0(0) ack 1 <mss 1460,nop,nop,sackOK,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey] >
-+0.01   < . 1:1(0) ack 1 win 257 <mpcapable v1 flags[flag_h] key[ckey=2,skey] >
-+0    accept(3, ..., ...) = 4
++0     bind(3, ..., ...) = 0
++0     listen(3, 1) = 0
++0       <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey] >
++0.01    <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey] >
++0     accept(3, ..., ...) = 4
 
 // the client shutdown its side
-+0.0   < P. 1:1(0) ack 1 win 450 <dss dack4=1 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
-+0.0   > . 1:1(0) ack 1 <dss dack4=2 nocs>
-+0.0   < F. 1:1(0) ack 1 win 450 <dss dack4=1 nocs>
-+0.0   > . 1:1(0) ack 2 <dss dack4=2 nocs>
++0.0     <  P.  1:1(0)  ack 1  win 450    <dss dack4=1 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
++0.0     >   .  1:1(0)  ack 1             <dss dack4=2 nocs>
++0.0     <  F.  1:1(0)  ack 1  win 450    <dss dack4=1 nocs>
++0.0     >   .  1:1(0)  ack 2             <dss dack4=2 nocs>
 
 // server shutdown
-+0   close(4) = 0
-+0     > . 1:1(0) ack 2 <dss dack4=2 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
-+0     < . 2:2(0) ack 1 win 450 <dss dack4=2 nocs>
-+0     > F. 1:1(0) ack 2 <dss dack4=2 nocs>
-+0     < . 2:2(0) ack 2 win 450 <dss dack4=2 nocs>
++0     close(4) = 0
++0       >   .  1:1(0)  ack 2             <dss dack4=2 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
++0       <   .  2:2(0)  ack 1  win 450    <dss dack4=2 nocs>
++0       >  F.  1:1(0)  ack 2             <dss dack4=2 nocs>
++0       <   .  2:2(0)  ack 2  win 450    <dss dack4=2 nocs>

--- a/gtests/net/mptcp/dss/dss_ssn_specified_client.pkt
+++ b/gtests/net/mptcp/dss/dss_ssn_specified_client.pkt
@@ -2,27 +2,30 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-
-0.0   socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
-+0.0  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
-+0.0  fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
-+0.0  fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+0.0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0    fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
++0.0    fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
 
 // Establish connection and verify that there was no error.
 
-+0.0  connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
-+0.0   > S 0:0(0) <mss 1460,sackOK,TS val 100 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
-+0.0   < S. 0:0(0) ack 1 win 65535 <mss 1460,sackOK,TS val 700 ecr 100,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey=2] >
-+0.0   > . 1:1(0) ack 1 <nop, nop, TS val 100 ecr 700,mpcapable v1 flags[flag_h] key[ckey,skey]>
-+0.200 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
-+0.205 fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
-+0.1   < P. 1:1001(1000) ack 1 win 450  <nop, nop, dss dack8=1 dsn8=1 ssn=1 dll=1000 nocs>
-+0.0   > . 1:1(0) ack 1001 <nop, nop, TS val 100 ecr 700,dss dack8=1001 ssn=1 dll=0 nocs>
-+0.3  read(3, ..., 1000) = 1000
-+0.0 write(3,..., 100) = 100
-+0.0   > P. 1:101(100) ack 1001 <nop, nop, TS val 100 ecr 700, dss dack8=1001 dsn8=1 ssn=1 dll=100 nocs, nop, nop>
-+0.0   < .  1001:1001(0) ack 101 win 450 <dss dack8=101 nocs>
-+0.4 close(3) = 0
-+0.0   > . 101:101(0) ack 1001 <nop, nop,TS val 100 ecr 700,dss dack8=1001 dsn8=101 ssn=0 dll=1 nocs fin, nop, nop>
-+0.0   < . 1001:1001(0) ack 101 win 450 <dss dack8=102 nocs>
-+0.0   > F. 101:101(0) ack 1001 <nop, nop,TS val 100 ecr 700, dss dack8=1001 nocs>
++0.0    connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
++0.0      >  S   0:0(0)                             <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++0.0      <  S.  0:0(0)        ack 1     win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.0      >   .  1:1(0)        ack 1                <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
+
++0.200  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.205  fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
+
++0.1      <  P.  1:1001(1000)  ack 1     win 450    <nop, nop,                     dss dack8=1    dsn8=1   ssn=1 dll=1000 nocs>
++0.0      >   .  1:1(0)        ack 1001             <nop, nop, TS val 100 ecr 700, dss dack8=1001          ssn=1 dll=0    nocs>
++0.3    read(3, ..., 1000) = 1000
+
++0.0    write(3, ..., 100) = 100
++0.0      >  P.  1:101(100)    ack 1001             <nop, nop, TS val 100 ecr 700, dss dack8=1001 dsn8=1   ssn=1 dll=100  nocs, nop, nop>
++0.0      <   .  1001:1001(0)  ack 101   win 450                                  <dss dack8=101                          nocs>
+
++0.4    close(3) = 0
++0.0      >   .  101:101(0)    ack 1001             <nop, nop, TS val 100 ecr 700, dss dack8=1001 dsn8=101 ssn=0 dll=1    nocs fin, nop, nop>
++0.0      <   .  1001:1001(0)  ack 101   win 450                                  <dss dack8=102                          nocs>
++0.0      >  F.  101:101(0)    ack 1001             <nop, nop, TS val 100 ecr 700, dss dack8=1001                         nocs>

--- a/gtests/net/mptcp/dss/dss_ssn_specified_server.pkt
+++ b/gtests/net/mptcp/dss/dss_ssn_specified_server.pkt
@@ -2,37 +2,36 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
++0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
 
-+0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
-+0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
-
-+0    bind(3, ..., ...) = 0
-+0    listen(3, 1) = 0
-+0      < S 0:0(0) win 32792 <mss 1460,sackOK,nop,nop,nop,wscale 7,mpcapable v1 flags[flag_h] nokey>
-+0      > S. 0:0(0) ack 1 <mss 1460,nop,nop,sackOK,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey] >
-+0.01   < . 1:1(0) ack 1 win 257 <mpcapable v1 flags[flag_h] key[ckey=2,skey]>
-+0    accept(3, ..., ...) = 4
++0     bind(3, ..., ...) = 0
++0     listen(3, 1) = 0
++0       <  S   0:0(0)                     win 32792  <mss 1460, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0       >  S.  0:0(0)           ack 1                <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.01    <   .  1:1(0)           ack 1     win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0     accept(3, ..., ...) = 4
 
 // send 2 data segments and ack them
-+0   write(4, ..., 1000) = 1000
-+0     > P. 1:1001(1000) ack 1 <dss dack4=1 dsn8=1 ssn=1 dll=1000 nocs, nop, nop>
-+0.1   < . 1:1(0) ack 1001 win 225 <dss dack8=1001 dsn8=1 ssn=1 dll=0 nocs, nop, nop>
++0     write(4, ..., 1000) = 1000
++0       >  P.  1:1001(1000)     ack 1                <dss dack4=1    dsn8=1    ssn=1    dll=1000 nocs,     nop, nop>
++0.1     <   .  1:1(0)           ack 1001  win 225    <dss dack8=1001 dsn8=1    ssn=1    dll=0    nocs,     nop, nop>
 
-+0   write(4, ..., 1000) = 1000
-+0     > P. 1001:2001(1000) ack 1 <dss dack4=1 dsn8=1001 ssn=1001 dll=1000 nocs, nop, nop>
-+0.1   < .  1:1(0) ack 2001 win 225 <dss dack8=2001 dsn8=1 ssn=1 dll=0 nocs, nop, nop>
++0     write(4, ..., 1000) = 1000
++0       >  P.  1001:2001(1000)  ack 1                <dss dack4=1    dsn8=1001 ssn=1001 dll=1000 nocs,     nop, nop>
++0.1     <   .  1:1(0)           ack 2001  win 225    <dss dack8=2001 dsn8=1    ssn=1    dll=0    nocs,     nop, nop>
 
 // read and ack 1 data segment
-+0     < P. 1:11(10) ack 2001 win 225 <dss dack8=2001 dsn8=1 ssn=1 dll=10 nocs, nop, nop>
-+0     > .  2001:2001(0) ack 11 <dss dack8=11 nocs>
-+0.3  read(4, ..., 10) = 10
++0       <  P.  1:11(10)         ack 2001  win 225    <dss dack8=2001 dsn8=1    ssn=1    dll=10   nocs,     nop, nop>
++0       >   .  2001:2001(0)     ack 11               <dss dack8=11                               nocs>
++0.3   read(4, ..., 10) = 10
 
 // send 1 more data segment, this time dack8 will have to be used: server sent dsn8
-+0   write(4, ..., 1000) = 1000
-+0     > P. 2001:3001(1000) ack 11 <dss dack8=11 dsn8=2001 ssn=2001 dll=1000 nocs, nop, nop>
-+0     < .  11:11(0) ack 3001 win 225 <dss dack8=3001 dsn8=10 ssn=1 dll=0 nocs, nop, nop>
++0     write(4, ..., 1000) = 1000
++0       >  P.  2001:3001(1000)  ack 11               <dss dack8=11   dsn8=2001 ssn=2001 dll=1000 nocs,     nop, nop>
++0       <   .  11:11(0)         ack 3001  win 225    <dss dack8=3001 dsn8=10   ssn=1    dll=0    nocs,     nop, nop>
 
-+0   close(4) = 0
-+0     > . 3001:3001(0) ack 11 <dss dack8=11 dsn8=3001 ssn=0 dll=1 nocs fin, nop, nop>
-+0     < . 11:11(0) ack 3001 win 225 <dss dack8=3002 nocs>
-+0     > F. 3001:3001(0) ack 11 <dss dack8=11 nocs>
++0     close(4) = 0
++0       >   .  3001:3001(0)     ack 11               <dss dack8=11   dsn8=3001 ssn=0    dll=1    nocs fin, nop, nop>
++0       <   .  11:11(0)         ack 3001  win 225    <dss dack8=3002                             nocs>
++0       >  F.  3001:3001(0)     ack 11               <dss dack8=11                               nocs>

--- a/gtests/net/mptcp/dss/mpc_with_data_client.pkt
+++ b/gtests/net/mptcp/dss/mpc_with_data_client.pkt
@@ -2,28 +2,29 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-
-0.0   socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
-+0.0  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
-+0.0  fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
-+0.0  fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+0.0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0    fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
++0.0    fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
 
 // Establish connection and verify that there was no error.
 
-+0.0  connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
-+0.01   > S 0:0(0) <mss 1460,sackOK,TS val 100 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
-+0.01   < S. 0:0(0) ack 1 win 65535 <mss 1460,sackOK,TS val 700 ecr 100,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey=2] >
-+0.01  > . 1:1(0) ack 1 <nop, nop, TS val 100 ecr 700,mpcapable v1 flags[flag_h] key[ckey,skey]>
-+0.200 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
-+0.205 fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
++0.0    connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
++0.01     >  S   0:0(0)                               <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++0.01     <  S.  0:0(0)          ack 1     win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.01     >   .  1:1(0)          ack 1                <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
+
++0.200  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.205  fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
 
 // send 2 data segments and get them acked by packetdrill
-+0.3  write(3, ..., 1000) = 1000
-+0.01   > P. 1:1001(1000) ack 1 <nop, nop, TS val 100 ecr 700, mpcapable v1 flags[flag_h] key[ckey,skey] mpcdatalen 1000, nop, nop>
-+0.01   < .  1:1(0) ack 1001 win 225 <dss dack8=1001 nocs>
-+0.1 write(3, ..., 500) = 500
-+0.01   > P. 1001:1501(500) ack 1 <nop, nop, TS val 100 ecr 700, dss dack4=1 dsn8=1001 ssn=1001 dll=500 nocs, nop, nop>
-+0.01   < .  1:201(200) ack 1501 win 225 <dss dack8=1501 dsn8=1 ssn=1 dll=200 nocs, nop, nop>
-+0.01   > .  1501:1501(0) ack 201 <nop, nop, TS val 100 ecr 700, dss dack8=201 dll=0 nocs>
-+0.1 read(3, ..., 200) = 200
++0.3    write(3, ..., 1000) = 1000
++0.01     >  P.  1:1001(1000)    ack 1                <nop, nop, TS val 100 ecr 700, mpcapable v1 flags[flag_h] key[ckey, skey] mpcdatalen 1000, nop, nop>
++0.01     <   .  1:1(0)          ack 1001  win 225                                  <dss dack8=1001 nocs>
 
++0.1    write(3, ..., 500) = 500
++0.01     >  P.  1001:1501(500)  ack 1                <nop, nop, TS val 100 ecr 700, dss dack4=1    dsn8=1001 ssn=1001 dll=500 nocs, nop, nop>
++0.01     <   .  1:201(200)      ack 1501  win 225                                  <dss dack8=1501 dsn8=1    ssn=1    dll=200 nocs, nop, nop>
++0.01     >   .  1501:1501(0)    ack 201              <nop, nop, TS val 100 ecr 700, dss dack8=201                     dll=0   nocs>
+
++0.1    read(3, ..., 200) = 200

--- a/gtests/net/mptcp/dss/mpc_with_data_server.pkt
+++ b/gtests/net/mptcp/dss/mpc_with_data_server.pkt
@@ -2,28 +2,27 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
++0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
 
-+0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
-+0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0     bind(3, ..., ...) = 0
++0     listen(3, 1) = 0
++0       <  S   0:0(0)                  win 32792  <mss 1460, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0       >  S.  0:0(0)        ack 1                <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.01    <   .  1:1(0)        ack 1     win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0     accept(3, ..., ...) = 4
 
-+0    bind(3, ..., ...) = 0
-+0    listen(3, 1) = 0
-+0      < S 0:0(0) win 32792 <mss 1460,sackOK,nop,nop,nop,wscale 7,mpcapable v1 flags[flag_h] nokey>
-+0      > S. 0:0(0) ack 1 <mss 1460,nop,nop,sackOK,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey]>
-+0.01   < . 1:1(0) ack 1 win 257 <mpcapable v1 flags[flag_h] key[ckey=2,skey]>
-+0    accept(3, ..., ...) = 4
-
-+0.01   < P. 1:101(100) ack 1 win 225 <mpcapable v1 flags[flag_h] key[ckey=2,skey] mpcdatalen 100, nop, nop>
-+0.01   > . 1:1(0) ack 101 <dss dack8=101 nocs>
++0.01    <  P.  1:101(100)    ack 1     win 225                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey] mpcdatalen 100, nop, nop>
++0.01    >   .  1:1(0)        ack 101              <dss dack8=101  nocs>
 
 // send 1 data segments and ack them
-+0    write(4, ..., 1000) = 1000
-+0      > P. 1:1001(1000) ack 101 <dss dack8=101 dsn8=1 ssn=1 dll=1000 nocs, nop, nop>
-+0.1    < . 101:101(0) ack 1001 win 225 <dss dack8=1001 dsn8=1 ssn=1 dll=100 nocs, nop, nop>
++0     write(4, ..., 1000) = 1000
++0       >  P.  1:1001(1000)  ack 101              <dss dack8=101  dsn8=1    ssn=1 dll=1000 nocs, nop, nop>
++0.1     <   .  101:101(0)    ack 1001  win 225    <dss dack8=1001 dsn8=1    ssn=1 dll=100  nocs, nop, nop>
 
 // read 100 bytes from the MPC+data
-+0.01 read(4, ..., 100) = 100
-+0    close(4) = 0
-+0      > . 1001:1001(0) ack 101 <dss dack8=101 dsn8=1001 ssn=0 dll=1 nocs fin, nop, nop>
-+0      < .  101:101(0) ack 1001 win 225 <dss dack8=1002 nocs>
-+0      > F. 1001:1001(0) ack 101 <dss dack8=101 nocs>
++0.01  read(4, ..., 100) = 100
++0     close(4) = 0
++0       >   .  1001:1001(0)  ack 101              <dss dack8=101  dsn8=1001 ssn=0 dll=1    nocs fin, nop, nop>
++0       <   .  101:101(0)    ack 1001  win 225    <dss dack8=1002 nocs>
++0       >  F.  1001:1001(0)  ack 101              <dss dack8=101  nocs>

--- a/gtests/net/mptcp/fastclose/receive_fastclose_with_ack.pkt
+++ b/gtests/net/mptcp/fastclose/receive_fastclose_with_ack.pkt
@@ -2,33 +2,33 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-+0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
-+0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
 
-+0    bind(3, ..., ...) = 0
-+0    listen(3, 1) = 0
-+0.0    < addr[caddr0] > addr[saddr0] S 0:0(0) win 65535 <mss 1460,nop,wscale 7,mpcapable v1 flags[flag_h] nokey>
-+0.0 > S. 0:0(0) ack 1 <mss 1460,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey]>
-+0.0 < . 1:1(0) ack 1 win 256 <mpcapable v1 flags[flag_h] key[ckey=2,skey]>
-+0    accept(3, ..., ...) = 4
++0     bind(3, ..., ...) = 0
++0     listen(3, 1) = 0
++0.0     <  S   0:0(0)                     win 65535  <mss 1460, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0.0     >  S.  0:0(0)           ack 1                <mss 1460, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.0     <   .  1:1(0)           ack 1     win 256                             <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0     accept(3, ..., ...) = 4
 
-+0.0  < P. 1:1001(1000) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=1 ssn=1 dll=1000 nocs>
-+0.0  >  . 1:1(0) ack 1001 <dss dack8=1001 nocs>
++0.0     <  P.  1:1001(1000)     ack 1     win 450    <nop, nop, dss dack8=1    dsn8=1    ssn=1    dll=1000 nocs>
++0.0     >   .  1:1(0)           ack 1001                       <dss dack8=1001 nocs>
 
 // send ack fastclose with a key that should not match.
-+0    < . 1001:1001(0) win 450 <mp_fastclose ckey=42 >
++0       <   .  1001:1001(0)               win 450              <mp_fastclose ckey=42>
 
 // more data, expect ack
-+1.0  < P. 1001:2001(1000) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=1001 ssn=1001 dll=1000 nocs>
-+0.0  > . 1:1(0) ack 2001 <dss dack8=2001 nocs>
++1.0     <  P.  1001:2001(1000)  ack 1     win 450    <nop, nop, dss dack8=1    dsn8=1001 ssn=1001 dll=1000 nocs>
++0.0     >   .  1:1(0)           ack 2001                       <dss dack8=2001 nocs>
 
 // send another ack fastclose, this time with matching key
-+0.1      < . 2001:2001(0) win 450 <mp_fastclose>
++0.1     <   .  2001:2001(0)               win 450              <mp_fastclose>
 // expect peer to reset all subflows now:
-+0.01 > R. 1:1(0) ack 2001
++0.01    >  R.  1:1(0)           ack 2001
 
 // more data, expect a reset and win0 (no socket anymore)
-+1.0  < P. 2001:3001(1000) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=2001 ssn=2001 dll=1000 nocs>
-+0.01 > R 1:1(0) ack 0 win 0
++1.0     <  P.  2001:3001(1000)  ack 1     win 450    <nop, nop, dss dack8=1    dsn8=2001 ssn=2001 dll=1000 nocs>
++0.01    >  R   1:1(0)           ack 0     win 0
 
-+0    close(4) = 0
++0     close(4) = 0

--- a/gtests/net/mptcp/fastclose/receive_fastclose_with_ack_multi_v4.pkt
+++ b/gtests/net/mptcp/fastclose/receive_fastclose_with_ack_multi_v4.pkt
@@ -9,44 +9,45 @@
 
 +0    bind(3, ..., ...) = 0
 +0    listen(3, 1) = 0
-+0.0    < addr[caddr0] > addr[saddr0] S 0:0(0) win 65535 <mss 1460,nop,wscale 7,mpcapable v1 flags[flag_h] nokey>
-+0.0 > S. 0:0(0) ack 1 <mss 1460,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey]>
-+0.0 < . 1:1(0) ack 1 win 256 <mpcapable v1 flags[flag_h] key[ckey=2,skey]>
++0.0    <  addr[caddr0] > addr[saddr0]  S   0:0(0)                  win 65535  <mss 1460, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0.0    >                               S.  0:0(0)        ack 1                <mss 1460, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.0    <                                .  1:1(0)        ack 1     win 256                             <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0    accept(3, ..., ...) = 4
 
 // add_addr
-+0.0 > . 1:1(0) ack 1 <add_address addr[saddr1] hmac=auto,dss dack4=1 dll=0 nocs>
++0.0    >                                .  1:1(0)        ack 1                <add_address addr[saddr1] hmac=auto, dss dack4=1                    dll=0    nocs>
 // TODO: send echo bit
-// +0.0 < . 1:1(0) ack 1 win 256 <add_address addr[saddr1],dss dack8=1 dll=0 nocs>
+// +0.0 <                                .  1:1(0)        ack 1     win 256    <add_address addr[saddr1],           dss dack8=1                    dll=0    nocs>
 
-+0.2  < P. 1:1001(1000) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=1 ssn=1 dll=1000 nocs>
-+0.0  >  . 1:1(0) ack 1001 <dss dack8=1001 nocs>
++0.2    <                               P.  1:1001(1000)  ack 1     win 450    <nop, nop,                           dss dack8=1    dsn8=1    ssn=1 dll=1000 nocs>
++0.0    >                                .  1:1(0)        ack 1001                                                 <dss dack8=1001 nocs>
 
-+0.2  < P. 1:1(0) ack 1 win 450 <mpcapable v1 flags[flag_h] key[skey,ckey]>
-+0.0  >  . 1:1(0) ack 1001 <dss dack8=1001 nocs>
++0.2    <                               P.  1:1(0)        ack 1     win 450                             <mpcapable v1 flags[flag_h] key[skey, ckey]>
++0.0    >                                .  1:1(0)        ack 1001                                                 <dss dack8=1001 nocs>
+
 
 // add another subflow.
-+0.5 < addr[caddr1] > addr[saddr1] S 0:0(0) win 65535 <mss 1460,nop,wscale 7,mp_join_syn address_id=2 token=sha256_32(skey)>
-+0.0 > S. 0:0(0) ack 1 <mss 1460,nop,wscale 8,mp_join_syn_ack address_id=0 sender_hmac=auto>
-+0.0 < . 1:1(0) ack 1 win 256 <mp_join_ack sender_hmac=auto>
-+0.0 > . 1:1(0) ack 1 <dss dack8=1001 nocs>
++0.5    <  addr[caddr1] > addr[saddr1]  S   0:0(0)                  win 65535  <mss 1460, nop, wscale 7, mp_join_syn     address_id=2 token=sha256_32(skey)>
++0.0    >                               S.  0:0(0)        ack 1                <mss 1460, nop, wscale 8, mp_join_syn_ack address_id=0 sender_hmac=auto>
++0.0    <                                .  1:1(0)        ack 1     win 256                             <mp_join_ack                  sender_hmac=auto>
++0.0    >                                .  1:1(0)        ack 1                          <dss dack8=1001 nocs>
 
 // send more data at mptcp level.
-+0.2  < P. 1:1002(1001) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=1001 ssn=1 dll=1001 nocs>
-+0.0  >  . 1:1(0) ack 1002 <dss dack8=2002 dll=0 nocs>
++0.2    <                               P.  1:1002(1001)  ack 1     win 450    <nop, nop, dss dack8=1    dsn8=1001 ssn=1 dll=1001 nocs>
++0.0    >                                .  1:1(0)        ack 1002                       <dss dack8=2002                 dll=0    nocs>
 
 // fastclose on the 2nd subflow, but old sequence numbers.
-+0.1  <  . 1:1(0) win 450 <mp_fastclose>
++0.1    <                                .  1:1(0)                  win 450              <mp_fastclose>
 
 // no effect expected.
-+0.0  >  . 1:1(0) ack 1002 <dss dack8=2002 dll=0 nocs>
++0.0    >                                .  1:1(0)        ack 1002                       <dss dack8=2002                 dll=0    nocs>
 
 // fastclose on the 2nd subflow, good sequence numbers.
-+0.1  <  . 1002:1002(0) win 450 <mp_fastclose>
++0.1    <                                .  1002:1002(0)            win 450              <mp_fastclose>
 
 // expect peer to reset both subflows now:
-+0.0  > addr[saddr0] > addr[caddr0] R. 1:1(0) ack 1001
-+0.0  > addr[saddr1] > addr[caddr1] R. 1:1(0) ack 1002
++0.0    >  addr[saddr0] > addr[caddr0]  R.  1:1(0)        ack 1001
++0.0    >  addr[saddr1] > addr[caddr1]  R.  1:1(0)        ack 1002
 
 +0    read(4, ..., 2002) = 2001
 +0    close(4) = 0

--- a/gtests/net/mptcp/fastclose/receive_fastclose_with_rst_multi_v4.pkt
+++ b/gtests/net/mptcp/fastclose/receive_fastclose_with_rst_multi_v4.pkt
@@ -9,41 +9,42 @@
 
 +0    bind(3, ..., ...) = 0
 +0    listen(3, 1) = 0
-+0.0    < addr[caddr0] > addr[saddr0] S 0:0(0) win 65535 <mss 1460,nop,wscale 7,mpcapable v1 flags[flag_h] nokey>
-+0.0 > S. 0:0(0) ack 1 <mss 1460,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey]>
-+0.0 < . 1:1(0) ack 1 win 256 <mpcapable v1 flags[flag_h] key[ckey=2,skey]>
++0.0    <  addr[caddr0] > addr[saddr0]  S   0:0(0)                  win 65535  <mss 1460, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0.0    >                               S.  0:0(0)        ack 1                <mss 1460, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.0    <                                .  1:1(0)        ack 1     win 256                             <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0    accept(3, ..., ...) = 4
 
 // add_addr
-+0.0 > . 1:1(0) ack 1 <add_address addr[saddr1] hmac=auto,dss dack4=1 dll=0 nocs>
++0.0    >                                .  1:1(0)        ack 1                <add_address addr[saddr1] hmac=auto, dss dack4=1                    dll=0    nocs>
 // TODO: send echo bit
-// +0.0 < . 1:1(0) ack 1 win 256 <add_address addr[saddr1],dss dack8=1 dll=0 nocs>
+// +0.0 <                                .  1:1(0)        ack 1     win 256    <add_address addr[saddr1],           dss dack8=1                    dll=0    nocs>
 
-+0.2  < P. 1:1001(1000) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=1 ssn=1 dll=1000 nocs>
-+0.0  >  . 1:1(0) ack 1001 <dss dack8=1001 nocs>
++0.2    <                               P.  1:1001(1000)  ack 1     win 450    <nop, nop,                           dss dack8=1    dsn8=1    ssn=1 dll=1000 nocs>
++0.0    >                                .  1:1(0)        ack 1001                                                 <dss dack8=1001 nocs>
 
-+0.2  < P. 1:1(0) ack 1 win 450 <mpcapable v1 flags[flag_h] key[skey,ckey]>
-+0.0  >  . 1:1(0) ack 1001 <dss dack8=1001 nocs>
++0.2    <                               P.  1:1(0)        ack 1     win 450                             <mpcapable v1 flags[flag_h] key[skey, ckey]>
++0.0    >                                .  1:1(0)        ack 1001                                                 <dss dack8=1001 nocs>
+
 
 // add another subflow.
-+0.5 < addr[caddr1] > addr[saddr1] S 0:0(0) win 65535 <mss 1460,nop,wscale 7,mp_join_syn address_id=2 token=sha256_32(skey)>
-+0.0 > S. 0:0(0) ack 1 <mss 1460,nop,wscale 8,mp_join_syn_ack address_id=0 sender_hmac=auto>
-+0.0 < . 1:1(0) ack 1 win 256 <mp_join_ack sender_hmac=auto>
-+0.0 > . 1:1(0) ack 1 <dss dack8=1001 nocs>
++0.5    <  addr[caddr1] > addr[saddr1]  S   0:0(0)                  win 65535  <mss 1460, nop, wscale 7, mp_join_syn     address_id=2 token=sha256_32(skey)>
++0.0    >                               S.  0:0(0)        ack 1                <mss 1460, nop, wscale 8, mp_join_syn_ack address_id=0 sender_hmac=auto>
++0.0    <                                .  1:1(0)        ack 1     win 256                             <mp_join_ack                  sender_hmac=auto>
++0.0    >                                .  1:1(0)        ack 1                          <dss dack8=1001 nocs>
 
 // send more data.
-+0.2  < P. 1:1002(1001) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=1001 ssn=1 dll=1001 nocs>
-+0    >  . 1:1(0) ack 1002 <dss dack8=2002 dll=0 nocs>
++0.2    <                               P.  1:1002(1001)  ack 1     win 450    <nop, nop, dss dack8=1    dsn8=1001 ssn=1 dll=1001 nocs>
++0      >                                .  1:1(0)        ack 1002                       <dss dack8=2002                 dll=0 nocs>
 
 // send rst fastclose.  Out of window, so it should have no effect.
-+0.1  < R. 3001:3001(0) win 450 <mp_fastclose>
-+0    >  . 1:1(0) ack 1002 <dss dack8=2002 dll=0 nocs>
++0.1    <                               R.  3001:3001(0)            win 450              <mp_fastclose>
++0      >                                .  1:1(0)        ack 1002                       <dss dack8=2002                 dll=0 nocs>
 
 // again. fastclose on the 2nd subflow.
-+0.1  < R. 1002:1002(0) win 450 <mp_fastclose>
++0.1    <                               R.  1002:1002(0)            win 450              <mp_fastclose>
 
 // expect peer to reset the original flow now:
-+0.0  > addr[saddr0] > addr[caddr0] R. 1:1(0) ack 1001
++0.0    >  addr[saddr0] > addr[caddr0]  R.  1:1(0)        ack 1001
 
 +0    read(4, ..., 2002) = 2001
 +0    close(4) = 0

--- a/gtests/net/mptcp/fastclose/receive_fastclose_with_rst_v4.pkt
+++ b/gtests/net/mptcp/fastclose/receive_fastclose_with_rst_v4.pkt
@@ -2,43 +2,46 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-+0    `../common/server.sh`
++0     `../common/server.sh`
 
-+0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
-+0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
 
-+0    bind(3, ..., ...) = 0
-+0    listen(3, 1) = 0
-+0.0    < addr[caddr0] > addr[saddr0] S 0:0(0) win 65535 <mss 1460,nop,wscale 7,mpcapable v1 flags[flag_h] nokey>
-+0.0 > S. 0:0(0) ack 1 <mss 1460,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey]>
-+0.0 < . 1:1(0) ack 1 win 256 <mpcapable v1 flags[flag_h] key[ckey=2,skey]>
-+0    accept(3, ..., ...) = 4
++0     bind(3, ..., ...) = 0
++0     listen(3, 1) = 0
++0.0     <  addr[caddr0] > addr[saddr0]  S   0:0(0)                     win 65535  <mss 1460, nop, wscale 7,  mpcapable v1 flags[flag_h] nokey>
++0.0     >                               S.  0:0(0)           ack 1                <mss 1460, nop, wscale 8,  mpcapable v1 flags[flag_h] key[skey]>
++0.0     <                                .  1:1(0)           ack 1     win 256                              <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0     accept(3, ..., ...) = 4
 
-+0.0  < P. 1:1001(1000) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=1 ssn=1 dll=1000 nocs>
-+0.0  >  . 1:1(0) ack 1001 <dss dack8=1001 nocs>
++0.0     <                               P.  1:1001(1000)     ack 1     win 450    <nop, nop,                 dss dack8=1    dsn8=1    ssn=1    dll=1000 nocs>
++0.0     >                                .  1:1(0)           ack 1001                                       <dss dack8=1001 nocs>
 
 // send rst fastclose with a key that should not match.
-+0     < R. 1001:1001(0) win 450 <mp_fastclose ckey=42 >
++0       <                               R.  1001:1001(0)                win 450   <mp_fastclose ckey=42>
 
 // more data, but expect rst: the subflow is gone.
-+1.0   < P. 1001:2001(1000) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=1001 ssn=1001 dll=1000 nocs>
-+0.02  > R 1:1(0) ack 0 win 0
++1.0     <                               P.  1001:2001(1000)  ack 1      win 450   <nop, nop,                 dss dack8=1    dsn8=1001 ssn=1001 dll=1000 nocs>
++0.02    >                               R   1:1(0)           ack 0      win 0
 
 // mp_join: supposed to work -- fastclose should have had no effect.
-+0.1  < addr[caddr0] > addr[saddr0] S 0:0(0) win 65535 <mss 1460,nop,wscale 7,mp_join_syn address_id=0 token=sha256_32(skey)>
-+0.0 > S. 0:0(0) ack 1 <mss 1460,nop,wscale 8,mp_join_syn_ack address_id=0 sender_hmac=auto>
-+0.0 < . 1:1(0) ack 1 win 256 <mp_join_ack sender_hmac=auto>
-+0.0 > . 1:1(0) ack 1 <add_address addr[saddr1] hmac=auto,dss dack8=1001 nocs>
++0.1     <  addr[caddr0] > addr[saddr0]  S   0:0(0)                      win 65535  <mss 1460, nop, wscale 7, mp_join_syn     address_id=0 token=sha256_32(skey)>
++0.0     >                               S.  0:0(0)           ack 1                 <mss 1460, nop, wscale 8, mp_join_syn_ack address_id=0 sender_hmac=auto>
++0.0     <                                .  1:1(0)           ack 1      win 256                             <mp_join_ack                  sender_hmac=auto>
+
++0.0     >                                .  1:1(0)           ack 1                 <add_address addr[saddr1] hmac=auto, dss dack8=1001 nocs>
+// TODO: send echo bit
+// +0.0  <                                .  1:1(0)           ack 1      win 256    <add_address addr[saddr1],           dss dack8=1    nocs>
 
 // more data, resend.  should work now.
-+0.0  < P. 1:1001(1000) ack 1 win 450 <nop,nop,dss dack8=1 dsn8=1001 ssn=1 dll=1000 nocs>
-+0.0  >  . 1:1(0) ack 1001 <dss dack8=2001 nocs>
++0.0     <                               P.  1:1001(1000)     ack 1      win 450    <nop, nop,                           dss dack8=1    dsn8=1001 ssn=1    dll=1000 nocs>
++0.0     >                                .  1:1(0)           ack 1001                                                  <dss dack8=2001 nocs>
 
 // send another rst fastclose, this time with matching key
-+0.1  < R. 1001:1001(0) win 450 <mp_fastclose>
++0.1     <                               R.  1001:1001(0)                win 450                                        <mp_fastclose>
 
 // more data, expect a reset and win0 (no socket anymore)
-+1.0  < P. 2001:3001(1000) ack 1 win 450 <nop, nop, dss dack8=1 dsn8=2001 ssn=1001 dll=1000 nocs>
-+0.01 > R 1:1(0) ack 0 win 0
++1.0     <                               P.  2001:3001(1000)  ack 1      win 450    <nop, nop,                           dss dack8=1    dsn8=2001 ssn=1001 dll=1000 nocs>
++0.01    >                               R   1:1(0)           ack 0      win 0
 
-+0    close(4) = 0
++0     close(4) = 0

--- a/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_flagB.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_flagB.pkt
@@ -2,22 +2,20 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-+0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
-+0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
 
-+0    bind(3, ..., ...) = 0
-+0    listen(3, 1) = 0
-+0      < S 0:0(0) win 32792 <mss 1460,sackOK,nop,nop,nop,wscale 8,mpcapable v1 flags 0x41 nokey>
-+0      > S. 0:0(0) ack 1 <mss 1460,nop,nop,sackOK,nop,wscale 8>
-+0.01   < . 1:1(0) ack 1 win 257
-+0    accept(3, ..., ...) = 4
++0     bind(3, ..., ...) = 0
++0     listen(3, 1) = 0
++0       <  S   0:0(0)         win 32792  <mss 1460, sackOK, nop, nop, nop, wscale 8, mpcapable v1 flags 0x41 nokey>
++0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8>
++0.01    <   .  1:1(0)  ack 1  win 257
++0     accept(3, ..., ...) = 4
 
 // ensure that traffic plane is functional and does not use DSS
 
-+0    write(4, ..., 1000) = 1000
-+0      > P. 1:1001(1000) ack 1
-+0      < P. 1:501(500) ack 1001 win 257
-+0      > . 1001:1001(0) ack 501
-+0    read(4, ..., 1000) = 500
-
-
++0     write(4, ..., 1000) = 1000
++0       >  P.  1:1001(1000)  ack 1
++0       <  P.  1:501(500)    ack 1001  win 257
++0       >   .  1001:1001(0)  ack 501
++0     read(4, ..., 1000) = 500

--- a/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_flagB_3rd_ack.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_flagB_3rd_ack.pkt
@@ -2,23 +2,20 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-+0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
-+0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
 
-+0    bind(3, ..., ...) = 0
-+0    listen(3, 1) = 0
-+0      < S 0:0(0) win 32792 <mss 1000,sackOK,nop,nop,nop,wscale 7,mpcapable v1 flags[flag_h]  nokey>
-+0      > S. 0:0(0) ack 1 <mss 1460,nop,nop,sackOK,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey] >
-+0.01   < . 1:1(0) ack 1 win 257 <mpcapable v1 flags [flag_b,flag_h] key[ckey=2,skey] >
-+0    accept(3, ..., ...) = 4
++0     bind(3, ..., ...) = 0
++0     listen(3, 1) = 0
++0       <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.01    <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_b, flag_h] key[ckey=2, skey] >
++0     accept(3, ..., ...) = 4
 
 // ensure that traffic plane is functional and does not use DSS
 
-+0    write(4, ..., 1000) = 1000
-+0      > P. 1:1001(1000) ack 1
-+0      < P. 1:501(500) ack 1001 win 257
-+0      > . 1001:1001(0) ack 501
-+0    read(4, ..., 1000) = 500
-
-
-
++0     write(4, ..., 1000) = 1000
++0       >  P.  1:1001(1000)  ack 1
++0       <  P.  1:501(500)    ack 1001  win 257
++0       >   .  1001:1001(0)  ack 501
++0     read(4, ..., 1000) = 500

--- a/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_flagH.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_flagH.pkt
@@ -2,22 +2,20 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-+0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
-+0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
 
-+0    bind(3, ..., ...) = 0
-+0    listen(3, 1) = 0
-+0      < S 0:0(0) win 32792 <mss 1460,sackOK,nop,nop,nop,wscale 8,mpcapable v1 flags 0x0 nokey>
-+0      > S. 0:0(0) ack 1 <mss 1460,nop,nop,sackOK,nop,wscale 8>
-+0.01   < . 1:1(0) ack 1 win 257
-+0    accept(3, ..., ...) = 4
++0     bind(3, ..., ...) = 0
++0     listen(3, 1) = 0
++0       <  S   0:0(0)         win 32792  <mss 1460, sackOK, nop, nop, nop, wscale 8, mpcapable v1 flags 0x0 nokey>
++0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8>
++0.01    <   .  1:1(0)  ack 1  win 257
++0     accept(3, ..., ...) = 4
 
 // ensure that traffic plane is functional and does not use DSS
 
-+0    write(4, ..., 1000) = 1000
-+0      > P. 1:1001(1000) ack 1
-+0      < P. 1:501(500) ack 1001 win 257
-+0      > . 1001:1001(0) ack 501
-+0    read(4, ..., 1000) = 500
-
-
++0     write(4, ..., 1000) = 1000
++0       >  P.  1:1001(1000)  ack 1
++0       <  P.  1:501(500)    ack 1001  win 257
++0       >   .  1001:1001(0)  ack 501
++0     read(4, ..., 1000) = 500

--- a/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_flagH_3rd_ack.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_flagH_3rd_ack.pkt
@@ -2,23 +2,20 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-+0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
-+0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
 
-+0    bind(3, ..., ...) = 0
-+0    listen(3, 1) = 0
-+0      < S 0:0(0) win 32792 <mss 1000,sackOK,nop,nop,nop,wscale 7,mpcapable v1 flags[flag_h]  nokey>
-+0      > S. 0:0(0) ack 1 <mss 1460,nop,nop,sackOK,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey] >
-+0.01   < . 1:1(0) ack 1 win 257 <mpcapable v1 flags 0x0 key[ckey=2,skey] >
-+0    accept(3, ..., ...) = 4
++0     bind(3, ..., ...) = 0
++0     listen(3, 1) = 0
++0       <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.01    <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags 0x0 key[ckey=2, skey]>
++0     accept(3, ..., ...) = 4
 
 // ensure that traffic plane is functional and does not use DSS
 
-+0    write(4, ..., 1000) = 1000
-+0      > P. 1:1001(1000) ack 1
-+0      < P. 1:501(500) ack 1001 win 257
-+0      > . 1001:1001(0) ack 501
-+0    read(4, ..., 1000) = 500
-
-
-
++0     write(4, ..., 1000) = 1000
++0       >  P.  1:1001(1000)  ack 1
++0       <  P.  1:501(500)    ack 1001  win 257
++0       >   .  1001:1001(0)  ack 501
++0     read(4, ..., 1000) = 500

--- a/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_wrongver.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_wrongver.pkt
@@ -2,22 +2,20 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-+0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
-+0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
 
-+0    bind(3, ..., ...) = 0
-+0    listen(3, 1) = 0
-+0      < S 0:0(0) win 32792 <mss 1460,sackOK,nop,nop,nop,wscale 8,mpcapable v0 flags[flag_h] key[ckey=2]>
-+0      > S. 0:0(0) ack 1 <mss 1460,nop,nop,sackOK,nop,wscale 8>
-+0.01   < . 1:1(0) ack 1 win 257
-+0    accept(3, ..., ...) = 4
++0     bind(3, ..., ...) = 0
++0     listen(3, 1) = 0
++0       <  S   0:0(0)         win 32792  <mss 1460, sackOK, nop, nop, nop, wscale 8, mpcapable v0 flags[flag_h] key[ckey=2]>
++0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8>
++0.01    <   .  1:1(0)  ack 1  win 257
++0     accept(3, ..., ...) = 4
 
 // ensure that traffic plane is functional and does not use DSS
 
-+0    write(4, ..., 1000) = 1000
-+0      > P. 1:1001(1000) ack 1
-+0      < P. 1:501(500) ack 1001 win 257
-+0      > . 1001:1001(0) ack 501
-+0    read(4, ..., 1000) = 500
-
-
++0     write(4, ..., 1000) = 1000
++0       >  P.  1:1001(1000)  ack 1
++0       <  P.  1:501(500)    ack 1001  win 257
++0       >   .  1001:1001(0)  ack 501
++0     read(4, ..., 1000) = 500

--- a/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_wrongver_3rd_ack.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_wrongver_3rd_ack.pkt
@@ -2,23 +2,20 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-+0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
-+0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
 
-+0    bind(3, ..., ...) = 0
-+0    listen(3, 1) = 0
-+0      < S 0:0(0) win 32792 <mss 1000,sackOK,nop,nop,nop,wscale 7,mpcapable v1 flags[flag_h]  nokey>
-+0      > S. 0:0(0) ack 1 <mss 1460,nop,nop,sackOK,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey] >
-+0.01   < . 1:1(0) ack 1 win 257 <mpcapable v0 flags[flag_h] key[ckey=2,skey] >
-+0    accept(3, ..., ...) = 4
++0     bind(3, ..., ...) = 0
++0     listen(3, 1) = 0
++0       <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.01    <   .  1:1(0)  ack 1  win 257                                               <mpcapable v0 flags[flag_h] key[ckey=2, skey]>
++0     accept(3, ..., ...) = 4
 
 // ensure that traffic plane is functional and does not use DSS
 
-+0    write(4, ..., 1000) = 1000
-+0      > P. 1:1001(1000) ack 1
-+0      < P. 1:501(500) ack 1001 win 257
-+0      > . 1001:1001(0) ack 501
-+0    read(4, ..., 1000) = 500
-
-
-
++0     write(4, ..., 1000) = 1000
++0       >  P.  1:1001(1000)  ack 1
++0       <  P.  1:501(500)    ack 1001  win 257
++0       >   .  1001:1001(0)  ack 501
++0     read(4, ..., 1000) = 500

--- a/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_flagB.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_flagB.pkt
@@ -2,25 +2,25 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-0.0   socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
-+0.0  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
-+0.0  fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
-+0.0  fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+0.0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0    fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
++0.0    fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
 
 // Establish connection and verify that there was no error.
 
-+0.0  connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
-+0.0   > S 0:0(0) <mss 1460,sackOK,TS val 100 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
-+0.0   < S. 0:0(0) ack 1 win 65535 <mss 1460,sackOK,TS val 700 ecr 100,nop,wscale 8,mpcapable v1 flags[flag_b,flag_h] key[skey=2] >
-+0.0   > . 1:1(0) ack 1  <nop,nop,TS val 100 ecr 700>
-+0.200 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
-+0.200 fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
++0.0    connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
++0.0      >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++0.0      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_b, flag_h] key[skey=2]>
++0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700>
+
++0.200  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.200  fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
 
 // ensure that traffic plane is functional and does not use DSS
 
-+0    write(3, ..., 1000) = 1000
-+0      > P. 1:1001(1000) ack 1 <nop,nop,TS val 100 ecr 700>
-+0      < P. 1:501(500) ack 1001 win 257
-+0      > . 1001:1001(0) ack 501 <nop,nop,TS val 100 ecr 700>
-+0    read(3, ..., 1000) = 500
-
++0      write(3, ..., 1000) = 1000
++0        >  P.  1:1001(1000)  ack 1              <nop, nop,  TS val 100 ecr 700>
++0        <  P.  1:501(500)    ack 1001  win 257
++0        >   .  1001:1001(0)  ack 501            <nop, nop,  TS val 100 ecr 700>
++0      read(3, ..., 1000) = 500

--- a/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_flagH.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_flagH.pkt
@@ -2,25 +2,25 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-0.0   socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
-+0.0  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
-+0.0  fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
-+0.0  fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+0.0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0    fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
++0.0    fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
 
 // Establish connection and verify that there was no error.
 
-+0.0  connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
-+0.0   > S 0:0(0) <mss 1460,sackOK,TS val 100 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
-+0.0   < S. 0:0(0) ack 1 win 65535 <mss 1460,sackOK,TS val 700 ecr 100,nop,wscale 8,mpcapable v1 flags 0x0 key[skey=2] >
-+0.0   > . 1:1(0) ack 1 <nop,nop,TS val 100 ecr 700>
-+0.200 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
-+0.200 fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
++0.0    connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
++0.0      >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++0.0      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags 0x0 key[skey=2]>
++0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700>
+
++0.200  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.200  fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
 
 // ensure that traffic plane is functional and does not use DSS
 
-+0    write(3, ..., 1000) = 1000
-+0      > P. 1:1001(1000) ack 1 <nop,nop,TS val 100 ecr 700>
-+0      < P. 1:501(500) ack 1001 win 257
-+0      > . 1001:1001(0) ack 501 <nop,nop,TS val 100 ecr 700>
-+0    read(3, ..., 1000) = 500
-
++0      write(3, ..., 1000) = 1000
++0        >  P.  1:1001(1000)  ack 1              <nop, nop,  TS val 100 ecr 700>
++0        <  P.  1:501(500)    ack 1001  win 257
++0        >   .  1001:1001(0)  ack 501            <nop, nop,  TS val 100 ecr 700>
++0      read(3, ..., 1000) = 500

--- a/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_wrongver.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_wrongver.pkt
@@ -2,25 +2,25 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-0.0   socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
-+0.0  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
-+0.0  fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
-+0.0  fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+0.0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0    fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
++0.0    fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
 
 // Establish connection and verify that there was no error.
 
-+0.0  connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
-+0.0   > S 0:0(0) <mss 1460,sackOK,TS val 100 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
-+0.0   < S. 0:0(0) ack 1 win 65535 <mss 1460,sackOK,TS val 700 ecr 100,nop,wscale 8,mpcapable v0 flags[flag_h] key[ckey=3,skey=2] >
-+0.0   > . 1:1(0) ack 1 <nop,nop,TS val 100 ecr 700>
-+0.200 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
-+0.200 fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
++0.0    connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
++0.0      >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++0.0      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v0 flags[flag_h] key[ckey=3, skey=2]>
++0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700>
+
++0.200  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.200  fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
 
 // ensure that traffic plane is functional and does not use DSS
 
-+0    write(3, ..., 1000) = 1000
-+0      > P. 1:1001(1000) ack 1 <nop,nop,TS val 100 ecr 700>
-+0      < P. 1:501(500) ack 1001 win 257
-+0      > . 1001:1001(0) ack 501 <nop,nop,TS val 100 ecr 700>
-+0    read(3, ..., 1000) = 500
-
++0      write(3, ..., 1000) = 1000
++0        >  P.  1:1001(1000)  ack 1              <nop, nop,  TS val 100 ecr 700>
++0        <  P.  1:501(500)    ack 1001  win 257
++0        >   .  1001:1001(0)  ack 501            <nop, nop,  TS val 100 ecr 700>
++0      read(3, ..., 1000) = 500

--- a/gtests/net/mptcp/mp_capable/v1_mp_capable_bind_no_cs.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_mp_capable_bind_no_cs.pkt
@@ -2,13 +2,13 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-+0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
-+0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
 
-+0    bind(3, ..., ...) = 0
-+0    listen(3, 1) = 0
-+0      < S 0:0(0) win 32792 <mss 1000,sackOK,nop,nop,nop,wscale 7,mpcapable v1 flags[flag_h] nokey>
-+0      > S. 0:0(0) ack 1 <mss 1460,nop,nop,sackOK,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey] >
-+0.01   < . 1:1(0) ack 1 win 257 <mpcapable v0 flags[flag_h] key[ckey=2,skey] >
-+0    accept(3, ..., ...) = 4
++0     bind(3, ..., ...) = 0
++0     listen(3, 1) = 0
 
++0       <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.01    <   .  1:1(0)  ack 1  win 257                                               <mpcapable v0 flags[flag_h] key[ckey=2, skey]>
++0     accept(3, ..., ...) = 4

--- a/gtests/net/mptcp/mp_capable/v1_mp_capable_connect_no_cs.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_mp_capable_connect_no_cs.pkt
@@ -2,16 +2,17 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-0.0   socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
-+0.0  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
-+0.0  fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
-+0.0  fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+0.0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0    fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
++0.0    fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
 
 // Establish connection and verify that there was no error.
 
-+0.0  connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
-+0.0   > S 0:0(0) <mss 1460,sackOK,TS val 100 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
-+0.0   < S. 0:0(0) ack 1 win 65535 <mss 1460,sackOK,TS val 700 ecr 100,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey=2] >
-+0.0   > . 1:1(0) ack 1 <nop,nop,TS val 100 ecr 700,mpcapable v1 flags[flag_h] key[ckey,skey] >
-+0.200 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
-+0.200 fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
++0.0    connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
++0.0      >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++0.0      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey] >
+
++0.200  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.200  fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking

--- a/gtests/net/mptcp/mp_join/mp_join_client_v4.pkt
+++ b/gtests/net/mptcp/mp_join/mp_join_client_v4.pkt
@@ -1,34 +1,35 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-+0   `../common/client.sh`
++0    `../common/client.sh`
 
 +0.0  socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
 +0.0  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
 +0.0  fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
 +0.0  fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
 
-+0.0 connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
-+0.0 > addr[caddr0] > addr[saddr0] S 0:0(0) <mss 1460,sackOK,TS val 4074410674 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
-+0.0 < S. 0:0(0) ack 1 win 65535 <mss 1460,sackOK,TS val 4074410674 ecr 4074410674,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey=2]>
-+0.0 > . 1:1(0) ack 1 <nop,nop,TS val 4074410674 ecr 4074410674,mpcapable v1 flags[flag_h] key[ckey,skey]>
-+0.2 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
-+0.0 fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
++0.0  connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
++0.0    >  addr[caddr0] > addr[saddr0]  S   0:0(0)                        <mss 1460, sackOK, TS val 4074410674 ecr 0,          nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++0.0    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.0    >                                .  1:1(0)      ack 1             <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
-+1.0 write(3,..., 2) = 2
-+0.0 > P. 1:3(2) ack 1 <nop,nop,TS val 4074418292 ecr 4074410674,mpcapable v1 flags[flag_h] key[ckey,skey] mpcdatalen 2,nop,nop>
-+0.0 < . 1:1(0) ack 3 win 256 <nop,nop,TS val 4074418293 ecr 4074418292,add_address addr[saddr1] hmac=auto,dss dack8=3 dll=0 nocs>
++0.2  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.0  fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
 
-+0.0 > > addr[saddr1] S 0:0(0) <mss 1460,sackOK,TS val 448955294 ecr 0,nop,wscale 8,mp_join_syn address_id=0 token=sha256_32(skey)>
-+0.0 > > addr[saddr0] . 3:3(0) ack 1 <nop, nop, TS val 448955294 ecr 448955294, add_address addr[saddr1], dss dack4=1 nocs>
++1.0  write(3, ..., 2) = 2
++0.0    >                               P.  1:3(2)      ack 1             <nop, nop, TS val 4074418292 ecr 4074410674,                        mpcapable v1 flags[flag_h] key[ckey, skey] mpcdatalen 2, nop, nop>
++0.0    <                                .  1:1(0)      ack 3  win 256    <nop, nop, TS val 4074418293 ecr 4074418292,       add_address addr[saddr1] hmac=auto, dss dack8=3   dll=0 nocs>
 
-+0.0 < S. 0:0(0) ack 1 win 65535 <mss 1460,sackOK,TS val 448955294 ecr 448955294,nop,wscale 8,mp_join_syn_ack address_id=1 sender_hmac=auto>
-+0.0 > . 1:1(0) ack 1 <nop,nop,TS val 448955294 ecr 448955294,mp_join_ack sender_hmac=auto>
-+0.0 < . 1:1(0) ack 1 win 256 <nop,nop,TS val 448955294 ecr 448955294, dss dack8=3 nocs>
-+1.0 < . 1:101(100) ack 1 win 256 <TS val 448955294 ecr 448955294, dss dack8=3 dsn8=1 ssn=1 dll=100 nocs>
-+0.0 > . 1:1(0) ack 101 <nop, nop, TS val 448955294 ecr 448955294, dss dack8=101 nocs>
-+0.0 read (3, ..., 100) = 100
-+0.1 close(3) = 0
-+0.0 > addr[caddr0] > addr[saddr0] . 3:3(0) ack 1 <nop,nop,TS val 4074418292 ecr 4074418293,dss dack8=101 dsn8=3 ssn=0 dll=1 nocs fin,nop,nop>
-+0.0 > . 1:1(0) ack 101 <nop,nop,TS val 4074418292 ecr 4074418293,dss dack8=101 dsn8=3 ssn=0 dll=1 nocs fin,nop,nop>
 
++0.0    >               > addr[saddr1]  S   0:0(0)                        <mss 1460, sackOK, TS val 448955294 ecr 0,         nop, wscale 8, mp_join_syn     address_id=0 token=sha256_32(skey)>
++0.0    >               > addr[saddr0]   .  3:3(0)      ack 1             <nop, nop,         TS val 448955294 ecr 448955294, add_address addr[saddr1],           dss dack4=1   nocs>
++0.0    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
++0.0    >                                .  1:1(0)      ack 1             <nop, nop,         TS val 448955294 ecr 448955294,                mp_join_ack                  sender_hmac=auto>
+
++0.0    <                                .  1:1(0)      ack 1  win 256    <nop, nop,         TS val 448955294 ecr 448955294, dss dack8=3   nocs>
++1.0    <                                .  1:101(100)  ack 1  win 256                      <TS val 448955294 ecr 448955294, dss dack8=3   dsn8=1 ssn=1 dll=100 nocs>
++0.0    >                                .  1:1(0)      ack 101           <nop, nop,         TS val 448955294 ecr 448955294, dss dack8=101 nocs>
++0.0  read (3, ..., 100) = 100
++0.1  close(3) = 0
++0.0    >  addr[caddr0] > addr[saddr0]   .  3:3(0)      ack 1             <nop, nop, TS val 4074418292 ecr 4074418293,       dss dack8=101 dsn8=3 ssn=0 dll=1 nocs fin, nop, nop>
++0.0    >                                .  1:1(0)      ack 101           <nop, nop, TS val 4074418292 ecr 4074418293,       dss dack8=101 dsn8=3 ssn=0 dll=1 nocs fin, nop, nop>

--- a/gtests/net/mptcp/mp_join/mp_join_server_bad_token.pkt
+++ b/gtests/net/mptcp/mp_join/mp_join_server_bad_token.pkt
@@ -11,5 +11,5 @@
 +0    bind(3, ..., ...) = 0
 +0    listen(3, 1) = 0
 
-+0.0 < S 0:0(0) win 65535 <mss 1460,mp_join_syn address_id=0 token=1>
-+0.0 > R. 0:0(0) ack 1
++0.0    <  S   0:0(0)        win 65535  <mss 1460, mp_join_syn address_id=0 token=1>
++0.0    >  R.  0:0(0) ack 1

--- a/gtests/net/mptcp/mp_join/mp_join_server_v4.pkt
+++ b/gtests/net/mptcp/mp_join/mp_join_server_v4.pkt
@@ -11,27 +11,28 @@
 +0    bind(3, ..., ...) = 0
 +0    listen(3, 1) = 0
 
-+0.0 < addr[caddr0] > addr[saddr0] S 0:0(0) win 65535 <mss 1460,sackOK,TS val 4074410674 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
-+0.0 > S. 0:0(0) ack 1 <mss 1460,sackOK,TS val 4074410674 ecr 4074410674,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey]>
-+0.0 < . 1:1(0) ack 1 win 256 <nop,nop,TS val 4074410674 ecr 4074410674,mpcapable v1 flags[flag_h] key[ckey=2,skey]>
++0.0    <  addr[caddr0] > addr[saddr0]  S   0:0(0)         win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 0,          nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++0.0    >                               S.  0:0(0)  ack 1             <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.0    <                                .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0    accept(3, ..., ...) = 4
 
 // add_addr
-+0.0 > . 1:1(0) ack 1 <nop,nop,TS val 4074418293 ecr 4074418292,add_address addr[saddr1] hmac=auto,dss dack4=1 dll=0 nocs>
++0.0    >                                .  1:1(0)  ack 1             <nop, nop,         TS val 4074418293 ecr 4074418292, add_address addr[saddr1] hmac=auto, dss dack4=1 dll=0 nocs>
 // TODO: send echo bit
-// +0.0 > . 1:1(0) ack 1 <nop,nop,TS val 4074418293 ecr 4074418292,add_address addr[saddr1],dss dack8=1 dll=0 nocs>
+// +0.0 <                                .  1:1(0)  ack 1             <nop, nop,         TS val 4074418293 ecr 4074418292, add_address addr[saddr1],           dss dack8=1 dll=0 nocs>
 
-+0.2 < P. 1:3(2) ack 1 win 256 <nop,nop,TS val 4074418292 ecr 4074410674,mpcapable v1 flags[flag_h] key[skey,ckey] mpcdatalen 2,nop,nop>
+
++0.2    <                               P.  1:3(2)  ack 1  win 256    <nop, nop,         TS val 4074418292 ecr 4074410674,                mpcapable v1 flags[flag_h] key[skey, ckey] mpcdatalen 2, nop, nop>
 // MP_CAPABLE carrying data are acked with 64-bit, safer not knowing if the
 // sender will use a DSN on 64-bit or 32-bit. Later we can use the lower 32 bits
-+0.0 > . 1:1(0) ack 3 <nop,nop,TS val 4074418293 ecr 4074418292,dss dack8=3 dll=0 nocs>
++0.0    >                                .  1:1(0)  ack 3             <nop, nop,         TS val 4074418293 ecr 4074418292,                dss dack8=3 dll=0 nocs>
 
 // create subflow
-+0.0 < addr[caddr1] > addr[saddr1] S 0:0(0) win 65535 <mss 1460,sackOK,TS val 448955294 ecr 0,nop,wscale 8,mp_join_syn backup=1 address_id=2 token=sha256_32(skey)>
-+0.0 > S. 0:0(0) ack 1 <mss 1460,sackOK,TS val 448955294 ecr 448955294,nop,wscale 8,mp_join_syn_ack backup=1 address_id=0 sender_hmac=auto>
-+0.0 < . 1:1(0) ack 1 win 256 <nop,nop,TS val 448955294 ecr 448955294,mp_join_ack sender_hmac=auto>
-+0.0 > . 1:1(0) ack 1 <nop,nop,TS val 448955294 ecr 448955294,dss dack8=3 nocs>
++0.0    <  addr[caddr1] > addr[saddr1]  S   0:0(0)         win 65535  <mss 1460, sackOK, TS val 448955294  ecr 0,          nop, wscale 8, mp_join_syn     backup=1 address_id=2 token=sha256_32(skey)>
++0.0    >                               S.  0:0(0)  ack 1             <mss 1460, sackOK, TS val 448955294  ecr 448955294,  nop, wscale 8, mp_join_syn_ack backup=1 address_id=0 sender_hmac=auto>
++0.0    <                                .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 448955294  ecr 448955294,                 mp_join_ack                           sender_hmac=auto>
++0.0    >                                .  1:1(0)  ack 1             <nop, nop,         TS val 448955294  ecr 448955294,                 dss dack8=3 nocs>
 
 // close connection
-+0.0 < addr[caddr0] > addr[saddr0] F. 3:3(0) ack 1 win 256 <nop,nop,TS val 4074418292 ecr 4074418293,dss dack4=1 dsn8=3 ssn=0 dll=1 nocs fin,nop,nop>
-+0.0 < > addr[saddr1] F. 1:1(0) ack 1 win 256 <nop,nop,TS val 448955294 ecr 448955294>
++0.0    <  addr[caddr0] > addr[saddr0]  F.  3:3(0)  ack 1  win 256    <nop, nop,         TS val 4074418292 ecr 4074418293,                dss dack4=1 dsn8=3 ssn=0 dll=1 nocs fin, nop, nop>
++0.0    <               > addr[saddr1]  F.  1:1(0)  ack 1  win 256    <nop, nop,         TS val 448955294  ecr 448955294>

--- a/gtests/net/mptcp/mp_prio/mp_prio_server_v4.pkt
+++ b/gtests/net/mptcp/mp_prio/mp_prio_server_v4.pkt
@@ -11,49 +11,48 @@
 +0    bind(3, ..., ...) = 0
 +0    listen(3, 1) = 0
 
-+0.0 < addr[caddr0] > addr[saddr0] S 0:0(0) win 65535 <mss 1460,sackOK,TS val 4074410674 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
-+0.0 > S. 0:0(0) ack 1 <mss 1460,sackOK,TS val 4074410674 ecr 4074410674,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey]>
-+0.0 < . 1:1(0) ack 1 win 256 <nop,nop,TS val 4074410674 ecr 4074410674,mpcapable v1 flags[flag_h] key[ckey=2,skey]>
++0.0    <  addr[caddr0] > addr[saddr0]  S   0:0(0)               win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 0,          nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++0.0    >                               S.  0:0(0)        ack 1             <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.0    <                                .  1:1(0)        ack 1  win 256    <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0    accept(3, ..., ...) = 4
 
 // add_addr
-+0.0 > . 1:1(0) ack 1 <nop,nop,TS val 4074418293 ecr 4074418292,add_address addr[saddr1] hmac=auto,dss dack4=1 dll=0 nocs>
++0.0    >                                .  1:1(0)        ack 1             <nop, nop, TS val 4074418293 ecr 4074418292, add_address addr[saddr1] hmac=auto, dss dack4=1  dll=0 nocs>
 // TODO: send echo bit
-// +0.0 > . 1:1(0) ack 1 <nop,nop,TS val 4074418293 ecr 4074418292,add_address addr[saddr1],dss dack8=1 dll=0 nocs>
+// +0.0 <                                .  1:1(0)        ack 1             <nop, nop, TS val 4074418293 ecr 4074418292, add_address addr[saddr1],           dss dack8=1  dll=0 nocs>
 
-+0.2 < P. 1:3(2) ack 1 win 256 <nop,nop,TS val 4074418292 ecr 4074410674,mpcapable v1 flags[flag_h] key[skey,ckey] mpcdatalen 2,nop,nop>
++0.2    <                               P.  1:3(2)        ack 1  win 256    <nop, nop, TS val 4074418292 ecr 4074410674,                        mpcapable v1 flags[flag_h] key[skey, ckey] mpcdatalen 2, nop, nop>
 // MP_CAPABLE carrying data are acked with 64-bit, safer not knowing if the
 // sender will use a DSN on 64-bit or 32-bit. Later we can use the lower 32 bits
-+0.0 > . 1:1(0) ack 3 <nop,nop,TS val 4074418293 ecr 4074418292,dss dack8=3 dll=0 nocs>
-+0.0 read(4, ..., 2) = 2
++0.0    >                                .  1:1(0)        ack 3             <nop, nop, TS val 4074418293 ecr 4074418292, dss dack8=3  dll=0 nocs>
++0.0  read(4, ..., 2) = 2
 
 // more inbound data and MP_PRIO to flip active -> backup
-+0.0 < P. 3:5(2) ack 1 win 256 <dss dack8=1 dsn4=3 ssn=3 dll=2 nocs, mp_prio backup=1, nop, nop, nop>
-+0.0 > . 1:1(0) ack 5 <nop,nop,TS val 4074418293 ecr 4074418292,dss dack4=5 nocs>
-+0.0 read(4, ..., 2) = 2
++0.0    <                               P.  3:5(2)        ack 1  win 256                                                <dss dack8=1  dsn4=3 ssn=3 dll=2  nocs, mp_prio backup=1, nop, nop, nop>
++0.0    >                                .  1:1(0)        ack 5             <nop, nop, TS val 4074418293 ecr 4074418292, dss dack4=5  nocs>
++0.0  read(4, ..., 2) = 2
 
 // create subflow
-+0.0 < addr[caddr1] > addr[saddr1] S 0:0(0) win 65535 <mss 1460,sackOK,TS val 448955294 ecr 0,nop,wscale 8,mp_join_syn backup=1 address_id=2 token=sha256_32(skey)>
-+0.0 > S. 0:0(0) ack 1 <mss 1460,sackOK,TS val 448955294 ecr 448955294,nop,wscale 8,mp_join_syn_ack backup=1 address_id=0 sender_hmac=auto>
-+0.0 < . 1:1(0) ack 1 win 256 <nop,nop,TS val 448955294 ecr 448955294,mp_join_ack sender_hmac=auto>
-+0.0 > . 1:1(0) ack 1 <nop,nop,TS val 448955294 ecr 448955294,dss dack4=5 nocs>
++0.0    <  addr[caddr1] > addr[saddr1]  S   0:0(0)               win 65535  <mss 1460, sackOK, TS val 448955294 ecr 0,         nop, wscale 8, mp_join_syn     backup=1 address_id=2 token=sha256_32(skey)>
++0.0    >                               S.  0:0(0)        ack 1             <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack backup=1 address_id=0 sender_hmac=auto>
++0.0    <                                .  1:1(0)        ack 1  win 256    <nop, nop, TS val 448955294 ecr 448955294,                        mp_join_ack sender_hmac=auto>
++0.0    >                                .  1:1(0)        ack 1             <nop, nop, TS val 448955294 ecr 448955294,                        dss dack4=5 nocs>
 
 // more inbound data and MP_PRIO to flip backup -> active
-+0.0 < P. 1:11(10) ack 1 win 256 <dss dack8=1 dsn4=5 ssn=1 dll=10 nocs, mp_prio backup=0, nop, nop, nop>
-+0.0 > . 1:1(0) ack 11 <nop,nop,TS val 448955294 ecr 448955294,dss dack4=15 nocs>
-+0.0 read(4, ..., 10) = 10
++0.0    <                               P.  1:11(10)      ack 1   win 256                                               <dss dack8=1  dsn4=5 ssn=1 dll=10 nocs, mp_prio backup=0, nop, nop, nop>
++0.0    >                                .  1:1(0)        ack 11            <nop, nop, TS val 448955294 ecr 448955294,   dss dack4=15 nocs>
++0.0  read(4, ..., 10) = 10
 
 // write() should now go through joined subflow
-+0.0 write(4, ..., 100) = 100
-+0.0 > addr[saddr1] > addr[caddr1] P. 1:101(100) ack 11 <nop,nop,TS val 448955294 ecr 448955294,dss dack4=15 dsn8=1 ssn=1 dll=100 nocs, nop, nop>
++0.0  write(4, ..., 100) = 100
++0.0    >  addr[saddr1] > addr[caddr1]  P.  1:101(100)    ack 11            <nop, nop, TS val 448955294 ecr 448955294,   dss dack4=15  dsn8=1 ssn=1 dll=100 nocs, nop, nop>
 // silently refuse v0 mp_prio
-+0.0 < addr[caddr1] > addr[saddr1] . 11:11(0) ack 101 win 256 <dss dack8=101 nocs, mp_prio backup=1 address_id=1>
-+0.0 write(4, ..., 100) = 100
-+0.0 > addr[saddr1] > addr[caddr1] P. 101:201(100) ack 11 <nop,nop,TS val 448955294 ecr 448955294,dss dack4=15 dsn8=101 ssn=101 dll=100 nocs, nop, nop>
-+0.0 < addr[caddr1] > addr[saddr1] . 11:11(0) ack 201 win 256 <dss dack8=201 nocs>
++0.0    <  addr[caddr1] > addr[saddr1]   .  11:11(0)      ack 101  win 256                                              <dss dack8=101 nocs, mp_prio backup=1 address_id=1>
++0.0  write(4, ..., 100) = 100
++0.0    >  addr[saddr1] > addr[caddr1]  P.  101:201(100)  ack 11            <nop, nop, TS val 448955294 ecr 448955294,   dss dack4=15  dsn8=101 ssn=101 dll=100 nocs, nop, nop>
++0.0    <  addr[caddr1] > addr[saddr1]   .  11:11(0)      ack 201  win 256                                              <dss dack8=201 nocs>
 
 // client sends DATA-FIN, subflows ack it
-+0.0 < addr[caddr1] > addr[saddr1] . 11:11(0) ack 201 win 256 <dss dack8=201 dsn8=15 dll=1 nocs fin, nop, nop>
-+0.0 > addr[saddr0] > addr[caddr0] . 1:1(0) ack 5 <nop,nop,TS val 448955294 ecr 448955294,dss dack4=16 nocs>
-+0.0 > addr[saddr1] > addr[caddr1] . 201:201(0) ack 11 <nop,nop,TS val 448955294 ecr 448955294,dss dack4=16 nocs>
-
++0.0    <  addr[caddr1] > addr[saddr1]   .  11:11(0)      ack 201  win 256                                              <dss dack8=201 dsn8=15 dll=1 nocs fin, nop, nop>
++0.0    >  addr[saddr0] > addr[caddr0]   .  1:1(0)        ack 5             <nop, nop, TS val 448955294 ecr 448955294,   dss dack4=16  nocs>
++0.0    >  addr[saddr1] > addr[caddr1]   .  201:201(0)    ack 11            <nop, nop, TS val 448955294 ecr 448955294,   dss dack4=16  nocs>

--- a/gtests/net/mptcp/regressions/unconnected_read.pkt
+++ b/gtests/net/mptcp/regressions/unconnected_read.pkt
@@ -3,9 +3,8 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-0.0   socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
-+0.0  fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
-+0.0  fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+0.0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0    fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
++0.0    fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
 
-+0.100 read(3, ..., 1000) = -1 ENOTCONN (Socket is not connected)
-
++0.100  read(3, ..., 1000) = -1  ENOTCONN (Socket is not connected)

--- a/gtests/net/mptcp/regressions/unconnected_shutdown.pkt
+++ b/gtests/net/mptcp/regressions/unconnected_shutdown.pkt
@@ -8,7 +8,7 @@
 +0.0  fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
 +0.0  fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
 
-+0.0 connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
-+0.0   > S 0:0(0) <mss 1460,sackOK,TS val 100 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
++0.0  connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
++0.0    >  S   0:0(0)  <mss 1460, sackOK, TS val 100 ecr 0, nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
 
-+0.0 shutdown(3, SHUT_WR) = 0
++0.0  shutdown(3, SHUT_WR) = 0

--- a/gtests/net/mptcp/regressions/zero_len_recvmsg.pkt
+++ b/gtests/net/mptcp/regressions/zero_len_recvmsg.pkt
@@ -4,21 +4,30 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-0.0   socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
-+0.1  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
-+0.1  fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
-+0.1  fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+0.0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.1   setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.1   fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
++0.1   fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
 
 // Establish connection and swap to blocking mode
-+0.0  connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
-+0.01   > S 0:0(0) <mss 1460,sackOK,TS val 100 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
-+0.01   < S. 0:0(0) ack 1 win 65535 <mss 1460,sackOK,TS val 700 ecr 100,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey=2] >
-+0.01 > . 1:1(0) ack 1 <nop, nop, TS val 100 ecr 700,mpcapable v1 flags[flag_h] key[ckey,skey]>
-+0.1 fcntl(3, F_SETFL, O_RDWR) = 0
++0.0   connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
++0.01    >  S   0:0(0)                          <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++0.01    <  S.  0:0(0)      ack 1    win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.01    >   .  1:1(0)      ack 1               <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
++0.1   fcntl(3, F_SETFL, O_RDWR) = 0
 
 // do 0 len recvmsg with and without pending data
-+0.1 recvmsg(3, {msg_name(...)=...,msg_iov(1)=[{..., 0}],msg_flags=0}, 0) = 0
-+0.1   < .  1:201(200) ack 1 win 225 <dss dack8=1 dsn8=1 ssn=1 dll=200 nocs, nop, nop>
-+0.01   > .  1:1(0) ack 201 <nop, nop, TS val 100 ecr 700, dss dack8=201 dll=0 nocs>
-+0.1 recvmsg(3, {msg_name(...)=...,msg_iov(1)=[{..., 0}],msg_flags=0}, 0) = 0
++0.1   recvmsg(3, {
+                     msg_name(...)=...,
+                     msg_iov(1)=[{..., 0}],
+                     msg_flags=0
+                  }, 0) = 0
 
++0.1     <   .  1:201(200)  ack 1    win 225                                  <dss dack8=1   dsn8=1 ssn=1 dll=200 nocs, nop, nop>
++0.01    >   .  1:1(0)      ack 201             <nop, nop, TS val 100 ecr 700, dss dack8=201              dll=0 nocs>
+
++0.1   recvmsg(3, {
+                     msg_name(...)=...,
+                     msg_iov(1)=[{..., 0}],
+                     msg_flags=0
+                   }, 0) = 0

--- a/gtests/net/mptcp/syscalls/connect_poll.pkt
+++ b/gtests/net/mptcp/syscalls/connect_poll.pkt
@@ -3,19 +3,19 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-0.0   socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
-+0.0  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
-+0.0  fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
-+0.0  fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+0.0         socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0        setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0        fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
++0.0        fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
 
 // Establish connection and verify we get timely poll wakeups
 
-+0.0  connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
-+0.0   > S 0:0(0) <mss 1460,sackOK,TS val 100 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
-+0.02  < S. 0:0(0) ack 1 win 65535 <mss 1460,sackOK,TS val 700 ecr 100,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey=2] >
-+0.0   > . 1:1(0) ack 1 <nop,nop,TS val 100 ecr 700,mpcapable v1 flags[flag_h] key[ckey,skey] >
++0.0        connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
++0.0          >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++0.02         <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.0          >   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
-+0...0.020 poll([{fd=3,
-		events=POLLOUT,
-		revents=POLLOUT}], 1, 1000) = 1
-+0.200 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0...0.020  poll([{fd=3,
+                   events=POLLOUT,
+                   revents=POLLOUT}], 1, 1000) = 1
++0.200      getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0

--- a/gtests/net/mptcp/syscalls/connect_reset_poll.pkt
+++ b/gtests/net/mptcp/syscalls/connect_reset_poll.pkt
@@ -3,19 +3,19 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-0.0   socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
-+0.0  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
-+0.0  fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
-+0.0  fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+0.0         socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0        setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0        fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
++0.0        fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
 
 // connection fails and verify that the error is properly
 // reported by poll()
 
-+0.0  connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
-+0.0   > S 0:0(0) <mss 1460,sackOK,TS val 100 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
-+0.02  < R. 0:0(0) ack 1 win 65535 <nop,nop,TS val 700 ecr 100>
++0.0        connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
++0.0          >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0, nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++0.02         <  R.  0:0(0)  ack 1  win 65535  <nop, nop,         TS val 700 ecr 100>
 
-+0...0.020 poll([{fd=3,
-		events=POLLOUT,
-		revents=POLLOUT|POLLERR|POLLHUP}], 1, 1000) = 1
-+0.200 getsockopt(3, SOL_SOCKET, SO_ERROR, [ECONNREFUSED], [4]) = 0
++0...0.020  poll([{fd=3,
+                   events=POLLOUT,
+                   revents=POLLOUT|POLLERR|POLLHUP}], 1, 1000) = 1
++0.200      getsockopt(3, SOL_SOCKET, SO_ERROR, [ECONNREFUSED], [4]) = 0

--- a/gtests/net/mptcp/syscalls/connect_reset_send.pkt
+++ b/gtests/net/mptcp/syscalls/connect_reset_send.pkt
@@ -3,21 +3,21 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-0.0   socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
-+0.0  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
-+0.0  fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
-+0.0  fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+0.0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0   setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0   fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
++0.0   fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
 
 // Establish connection and verify that blocking send()
 // fails as soon as the connection attempt fails
 
-+0.0  connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
-+0.0   > S 0:0(0) <mss 1460,sackOK,TS val 100 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
++0.0   connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
++0.0     >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0, nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
 
 
-+0.0  send(3, ..., 400, 0) = -1  EAGAIN (Resource temporarily unavailable)
-+0.0  fcntl(3, F_SETFL, O_RDWR) = 0
++0.0   send(3, ..., 400, 0) = -1  EAGAIN (Resource temporarily unavailable)
++0.0   fcntl(3, F_SETFL, O_RDWR) = 0
 
-+0.02  < R. 0:0(0) ack 1 win 65535 <nop,nop,TS val 700 ecr 100>
++0.02    <  R.  0:0(0)  ack 1  win 65535  <nop, nop,         TS val 700 ecr 100>
 
-+0...0.020 send(3, ..., 400, 0) = -1 ECONNREFUSED (Software caused connection abort)
++0...0.020  send(3, ..., 400, 0) = -1  ECONNREFUSED (Software caused connection abort)

--- a/gtests/net/mptcp/syscalls/connect_send.pkt
+++ b/gtests/net/mptcp/syscalls/connect_send.pkt
@@ -3,22 +3,21 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-0.0   socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
-+0.0  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
-+0.0  fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
-+0.0  fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+0.0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0   setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0   fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
++0.0   fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
 
 // Establish connection and verify blocking write will be woken-up by
 // MPC completion
 
-+0.0  connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
-+0.0   > S 0:0(0) <mss 1460,sackOK,TS val 100 ecr 0,nop,wscale 8,mpcapable v1 flags[flag_h] nokey>
++0.0   connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
++0.0     >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
 
++0.0   send(3, ..., 400, 0) = -1  EAGAIN (Resource temporarily unavailable)
++0.0   fcntl(3, F_SETFL, O_RDWR) = 0
 
-+0.0  send(3, ..., 400, 0) = -1  EAGAIN (Resource temporarily unavailable)
-+0.0  fcntl(3, F_SETFL, O_RDWR) = 0
++0.02    <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.0     >   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
-+0.02  < S. 0:0(0) ack 1 win 65535 <mss 1460,sackOK,TS val 700 ecr 100,nop,wscale 8,mpcapable v1 flags[flag_h] key[skey=2] >
-+0.0   > . 1:1(0) ack 1 <nop,nop,TS val 100 ecr 700,mpcapable v1 flags[flag_h] key[ckey,skey] >
-
-+0...0.020 send(3, ..., 400, 0) = 400
++0...0.020  send(3, ..., 400, 0) = 400


### PR DESCRIPTION
It is sometimes hard to read these scripts with all the options related
to TCP and MPTCP. Here, we are trying to improve that by adding some
columns and aligning the same attributes together.

Here is the new "code style" proposed here:

 - (minimum) 2 spaces between each section: times, syscalls, directions, flags, ACK, Win, options,...
 - Align all syscalls together: two spaces after the larger time
 - Align TCP flags (S, ., P, F, R)
 - It's OK to align per block, e.g. align for the initiation of the connection but it can be different for the options during a transfer
 - Spaces after commas in TCP options
 - Blank lines between blocks

Signed-off-by: Matthieu Baerts <matthieu.baerts@tessares.net>