### PR TITLE
mptcp: new syscall test for full DATA_FIN handshake after close

### DIFF
--- a/gtests/net/mptcp/dss/dss_ssn_specified_client.pkt
+++ b/gtests/net/mptcp/dss/dss_ssn_specified_client.pkt
@@ -28,4 +28,3 @@
 +0.4    close(3) = 0
 +0.0      >   .  101:101(0)    ack 1001             <nop, nop, TS val 100 ecr 700, dss dack8=1001 dsn8=101 ssn=0 dll=1    nocs fin, nop, nop>
 +0.0      <   .  1001:1001(0)  ack 101   win 450                                  <dss dack8=102                          nocs>
-+0.0      >  F.  101:101(0)    ack 1001             <nop, nop, TS val 100 ecr 700, dss dack8=1001                         nocs>

--- a/gtests/net/mptcp/dss/dss_ssn_specified_server.pkt
+++ b/gtests/net/mptcp/dss/dss_ssn_specified_server.pkt
@@ -34,4 +34,3 @@
 +0     close(4) = 0
 +0       >   .  3001:3001(0)     ack 11               <dss dack8=11   dsn8=3001 ssn=0    dll=1    nocs fin, nop, nop>
 +0       <   .  11:11(0)         ack 3001  win 225    <dss dack8=3002                             nocs>
-+0       >  F.  3001:3001(0)     ack 11               <dss dack8=11                               nocs>

--- a/gtests/net/mptcp/dss/mpc_with_data_server.pkt
+++ b/gtests/net/mptcp/dss/mpc_with_data_server.pkt
@@ -25,4 +25,3 @@
 +0     close(4) = 0
 +0       >   .  1001:1001(0)  ack 101              <dss dack8=101  dsn8=1001 ssn=0 dll=1    nocs fin, nop, nop>
 +0       <   .  101:101(0)    ack 1001  win 225    <dss dack8=1002 nocs>
-+0       >  F.  1001:1001(0)  ack 101              <dss dack8=101  nocs>

--- a/gtests/net/mptcp/syscalls/connect_close_ack_ooo.pkt
+++ b/gtests/net/mptcp/syscalls/connect_close_ack_ooo.pkt
@@ -18,6 +18,4 @@
 +0.0    close(3) = 0
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=1 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
 +0.0      <   .  2:2(0)  ack 1  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
-+0.0      >  F.  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=1 nocs>
-+0.0      <   .  2:2(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
 

--- a/gtests/net/mptcp/syscalls/connect_close_full.pkt
+++ b/gtests/net/mptcp/syscalls/connect_close_full.pkt
@@ -19,3 +19,15 @@
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=1 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
 +0.0      <   .  1:1(0)  ack 1  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
 
+// incoming DATA_FIN should be acked, using 4 bytes dsn, just for more noise
+
++0.0      <   .  1:1(0)  ack 1  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 dsn4=1 ssn=0 dll=1 nocs fin, nop, nop>
++0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
++0.0      >  F.  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
++0.0      <   .  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
++0.0      <  F.  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
+
+// the final ack will be emitted by a time-wait socket, no dack/mptcp options
+
++0.0      >   .  2:2(0)  ack 2             <nop, nop,         TS val 101 ecr 700>
+


### PR DESCRIPTION
Similar to the above, but it tests the full DATA FIN handshake
- both ways. Currently fails on export branch and requires
additional fixes.

Signed-off-by: Paolo Abeni <pabeni@redhat.com>