### PR TITLE
mptcp: close-full: delay the last injected FIN

### DIFF
--- a/gtests/net/mptcp/syscalls/connect_close_full.pkt
+++ b/gtests/net/mptcp/syscalls/connect_close_full.pkt
@@ -25,7 +25,9 @@
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
 +0.0      >  F.  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
 +0.0      <   .  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
-+0.0      <  F.  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
+
+// reply with a small delay to let the kernel switching to a time-wait socket.
++0.2      <  F.  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
 
 // the final ack will be emitted by a time-wait socket, no dack/mptcp options
 


### PR DESCRIPTION
With a debug kernel and a slow environment, the final ACK sent by the
kernel was with MPTCP options. If we leave a bit of time for the kernel
to switch to a time-wait socket, we have the expected behaviour.

Suggested-by: Paolo Abeni <pabeni@redhat.com>
Signed-off-by: Matthieu Baerts <matthieu.baerts@tessares.net>