### PR TITLE
mptcp: poll/accept test for incoming MPJ subflow

### DIFF
--- a/gtests/net/mptcp/syscalls/accept_v4.pkt
+++ b/gtests/net/mptcp/syscalls/accept_v4.pkt
@@ -1,0 +1,37 @@
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
++0    `../common/server.sh`
+
++0.0  socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0  fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
++0.0  fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+
++0    bind(3, ..., ...) = 0
++0    listen(3, 1) = 0
+
++0.0    <  addr[caddr0] > addr[saddr0]  S   0:0(0)         win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 0,          nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++0.0    >                               S.  0:0(0)  ack 1             <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.0    <                                .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0    accept(3, ..., ...) = 4
+
+// add_addr
++0.0    >                                .  1:1(0)  ack 1             <nop, nop,         TS val 4074418293 ecr 4074418292, add_address addr[saddr1] hmac=auto, dss dack4=1 dll=0 nocs>
+// TODO: send echo bit
+// +0.0 <                                .  1:1(0)  ack 1             <nop, nop,         TS val 4074418293 ecr 4074418292, add_address addr[saddr1],           dss dack8=1 dll=0 nocs>
+
++0.2    <                               P.  1:3(2)  ack 1  win 256    <nop, nop,         TS val 4074418292 ecr 4074410674,                mpcapable v1 flags[flag_h] key[skey, ckey] mpcdatalen 2, nop, nop>
+// MP_CAPABLE carrying data are acked with 64-bit, safer not knowing if the
+// sender will use a DSN on 64-bit or 32-bit. Later we can use the lower 32 bits
++0.0    >                                .  1:1(0)  ack 3             <nop, nop,         TS val 4074418293 ecr 4074418292,                dss dack8=3 dll=0 nocs>
+
+// create subflow
++0.0    <  addr[caddr1] > addr[saddr1]  S   0:0(0)         win 65535  <mss 1460, sackOK, TS val 448955294  ecr 0,          nop, wscale 8, mp_join_syn     backup=1 address_id=2 token=sha256_32(skey)>
++0.0    >                               S.  0:0(0)  ack 1             <mss 1460, sackOK, TS val 448955294  ecr 448955294,  nop, wscale 8, mp_join_syn_ack backup=1 address_id=0 sender_hmac=auto>
++0.0    <                                .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 448955294  ecr 448955294,                 mp_join_ack                           sender_hmac=auto>
++0.0    >                                .  1:1(0)  ack 1             <nop, nop,         TS val 448955294  ecr 448955294,                 dss dack8=3 nocs>
+
+// no poll/accept events
++0    poll([{fd=3, events=POLLIN, revents=0}], 1, 0) = 0
++0    accept(3, ..., ...) = -1 EAGAIN (Resource temporarily unavailable)

--- a/gtests/net/mptcp/syscalls/close_before_accept.pkt
+++ b/gtests/net/mptcp/syscalls/close_before_accept.pkt
@@ -1,0 +1,31 @@
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
++0    `../common/server.sh`
+
++0.0  socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0  fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
++0.0  fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+
++0    bind(3, ..., ...) = 0
++0    listen(3, 1) = 0
+
++0.0    <  S   0:0(0)         win 65535  <mss 1460, sackOK, TS val 700 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++0.0    >  S.  0:0(0)  ack 1             <mss 1460, sackOK, TS val 100 ecr 700, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.0    <   .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 700 ecr 100,                mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.2    <  P.  1:3(2)  ack 1  win 256    <nop, nop,         TS val 700 ecr 100,                mpcapable v1 flags[flag_h] key[skey, ckey] mpcdatalen 2, nop, nop>
+
+// MP_CAPABLE carrying data are acked with 64-bit, safer not knowing if the
+// sender will use a DSN on 64-bit or 32-bit. Later we can use the lower 32 bits
++0.0    >   .  1:1(0)  ack 3             <nop, nop,         TS val 100 ecr 700,                dss dack8=3 dll=0 nocs>
+
+// incoming reset will destory the first subflow and msk
++0.2    <  R.  3:3(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100,                dss dack4=2 nocs>
+
+// msk still exists and is established
++0    poll([{fd=3, events=POLLIN, revents=POLLIN}], 1, 0) = 1
++0    accept(3, ..., ...) = 4
+
+// no easy way to check for established status, anyhow write will just work
++0    write(4, ..., 100) = 100


### PR DESCRIPTION
This test verify no poll event is raised after
incoming MPJ subflow.

Needs: ("mptcp: do not wakeup listener for MPJ subflows")

Signed-off-by: Paolo Abeni <pabeni@redhat.com>
---
Note I see failure for the ipv6 variant: the automatically
generated ADD_ADDR options is wrong; it uses an ipv4
address. But that looks an core pktdrill issue ?!?