### PR TITLE
fix inbound HMAC for ADD_ADDR with port

### DIFF
--- a/gtests/net/packetdrill/mptcp.c
+++ b/gtests/net/packetdrill/mptcp.c
@@ -1991,7 +1991,7 @@ int mptcp_subtype_add_address(struct packet *packet_to_modify,
                                                            mp_state.kernel_key,
                                                            add_addr_script->data.add_addr.address_id,
                                                            &add_addr_script->data.add_addr.ipv4_w_port_hmac.ipv4,
-                                                           0);
+                                                           ntohs(add_addr_script->data.add_addr.ipv4_w_port_hmac.port));
 		}else if(add_addr_live->length == TCPOLEN_ADD_ADDR_V6){
 			add_addr_live->data.add_addr.ipv6 = endpoint->ip.ip.v6;
 		}else if(add_addr_live->length == TCPOLEN_ADD_ADDR_V6_PORT){
@@ -2017,7 +2017,7 @@ int mptcp_subtype_add_address(struct packet *packet_to_modify,
                                                            mp_state.kernel_key,
                                                            add_addr_script->data.add_addr.address_id,
                                                            &add_addr_script->data.add_addr.ipv6_w_port_hmac.ipv6,
-                                                           0);
+                                                           ntohs(add_addr_script->data.add_addr.ipv6_w_port_hmac.port));
 		}else
 			return STATUS_ERR;
 	}else if(direction == DIRECTION_OUTBOUND){


### PR DESCRIPTION
port was still hardcoded to 0

Fixes: 58039d6f348f ("packetdrill: fix a couple of errors when parsing ADD_ADDR with ports")
