### PR TITLE
fix ipv6 coverage for client scripts

### DIFF
--- a/gtests/net/mptcp/add_addr/add_addr_client.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr_client.pkt
@@ -24,10 +24,10 @@
 // time, causing the host to retransmit its last data packet. Here we ensure
 // this previous packet is acked then we can send the ADD_ADDR
 +0.0      <   .  1:1(0)  ack 101  win 256  <nop, nop, TS val 705 ecr 305,                                    dss dack8=101 dll=0 nocs>
-+0.0      <   .  1:1(0)  ack 101  win 256  <nop, nop, TS val 705 ecr 305, add_address addr[saddr] hmac=auto, dss dack8=101 dll=0 nocs>
++0.0      <   .  1:1(0)  ack 101  win 256  <nop, nop, TS val 705 ecr 305, add_address addr[saddr] hmac=auto>
 
 // ADD_ADDR echo (without hmac)
-+0.0      >   .  101:101(0)  ack 1         <nop, nop, TS val 494 ecr 700, add_address addr[saddr] addr_echo, dss dack4=1   dll=1 nocs>
++0.0      >   .  101:101(0)  ack 1         <nop, nop, TS val 494 ecr 700, add_address addr[saddr] addr_echo>
 
 +0.0 close(3) = 0
 +0.0      >   .  101:101(0)  ack 1         <nop, nop, TS val 494 ecr 700,                                    dss dack4=1   dsn8=101 ssn=0 dll=1 nocs fin, nop, nop>

--- a/gtests/net/mptcp/mp_join/mp_join_client.pkt
+++ b/gtests/net/mptcp/mp_join/mp_join_client.pkt
@@ -18,11 +18,11 @@
 
 +1.0  write(3, ..., 2) = 2
 +0.0    >                               P.  1:3(2)      ack 1             <nop, nop, TS val 4074418292 ecr 4074410674,                        mpcapable v1 flags[flag_h] key[ckey, skey] mpcdatalen 2, nop, nop>
-+0.0    <                                .  1:1(0)      ack 3  win 256    <nop, nop, TS val 4074418293 ecr 4074418292,       add_address addr[saddr1] hmac=auto, dss dack8=3   dll=0 nocs>
++0.0    <                                .  1:1(0)      ack 3  win 256    <nop, nop, TS val 4074418293 ecr 4074418292,       add_address addr[saddr1] hmac=auto>
 
 
 +0.0    >               > addr[saddr1]  S   0:0(0)                        <mss 1460, sackOK, TS val 448955294 ecr 0,         nop, wscale 8, mp_join_syn     address_id=0 token=sha256_32(skey)>
-+0.0    >               > addr[saddr0]   .  3:3(0)      ack 1             <nop, nop,         TS val 448955294 ecr 448955294, add_address addr[saddr1] addr_echo, dss dack4=1   nocs>
++0.0    >               > addr[saddr0]   .  3:3(0)      ack 1             <nop, nop,         TS val 448955294 ecr 448955294, add_address addr[saddr1] addr_echo>
 +0.0    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
 +0.0    >                                .  1:1(0)      ack 1             <nop, nop,         TS val 448955294 ecr 448955294,                mp_join_ack                  sender_hmac=auto>
 


### PR DESCRIPTION
an inbound ADD_ADDR without any DSS option fits the TCP option space
both with IPv4 and IPv6 addressing. Assuming that the kernel under test
doesn't send DSS in the ADD_ADDR echo, we can use a single client script
both for IPv4 and IPv6.

Signed-off-by: Davide Caratti <dcaratti@redhat.com>