### PR TITLE
Add DATA_FIN retransmission tests

### DIFF
--- a/gtests/net/mptcp/dss/dss_fin_retrans_close_wait.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_retrans_close_wait.pkt
@@ -1,0 +1,33 @@
+// Test data_fin retransmission from kernel TCP_CLOSE_WAIT state
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
++0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
+
++0     bind(3, ..., ...) = 0
++0     listen(3, 1) = 0
++0       <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.01    <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0     accept(3, ..., ...) = 4
+
+// the client shutdown its side
++0.0     <  P.  1:1(0)  ack 1  win 450    <dss dack4=1 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
++0.0     >   .  1:1(0)  ack 1             <dss dack4=2 nocs>
++0.0     <  F.  1:1(0)  ack 1  win 450    <dss dack4=1 nocs>
++0.0     >   .  1:1(0)  ack 2             <dss dack4=2 nocs>
+
+// server shutdown
++0     close(4) = 0
++0       >   .  1:1(0)  ack 2             <dss dack4=2 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
+
+// wait for retransmissions
++0.200   >   .  1:1(0)  ack 2             <dss dack4=2 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
++0.200   >   .  1:1(0)  ack 2             <dss dack4=2 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
++0.400   >   .  1:1(0)  ack 2             <dss dack4=2 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
+
+// ACK the data_fin
++0       <   .  2:2(0)  ack 1  win 450    <dss dack4=2 nocs>
++0       >  F.  1:1(0)  ack 2             <dss dack4=2 nocs>
++0       <   .  2:2(0)  ack 2  win 450    <dss dack4=2 nocs>

--- a/gtests/net/mptcp/dss/dss_fin_retrans_established.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_retrans_established.pkt
@@ -1,0 +1,28 @@
+// Test data_fin retransmission from kernel TCP_ESTABLISHED state
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
++0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
+
++0     bind(3, ..., ...) = 0
++0     listen(3, 1) = 0
++0       <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.01    <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0     accept(3, ..., ...) = 4
+
+// server shutdown
++0     close(4) = 0
++0       >   .  1:1(0)  ack 1             <dss dack4=1 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
+
+// wait for retransmissions
++0.200   >   .  1:1(0)  ack 1             <dss dack4=1 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
++0.200   >   .  1:1(0)  ack 1             <dss dack4=1 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
++0.400   >   .  1:1(0)  ack 1             <dss dack4=1 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
+
+// ACK the data_fin
++0       <   .  2:2(0)  ack 1  win 450    <dss dack4=2 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
++0       >   .  1:1(0)  ack 1             <dss dack4=2 nocs>
++0       >  F.  1:1(0)  ack 1             <dss dack4=2 nocs>
++0       <  F.  2:2(0)  ack 2  win 450    <dss dack4=2 nocs>


### PR DESCRIPTION
Covers two scenarios:

1. Packetdrill first injects a DATA_FIN to put the kernel in CLOSE_WAIT
before testing DATA_FIN retransmission in the LAST_ACK state.

2. The socket is closed on the kernel side first, transitioning from
ESTABLISHED and testing DATA_FIN retransmission in FIN_WAIT1.

Signed-off-by: Mat Martineau <mathew.j.martineau@linux.intel.com>