### PR TITLE
enable IPv6 test on server scripts that use more than 1 subflow

### DIFF
--- a/gtests/net/mptcp/common/multi-ep.sh
+++ b/gtests/net/mptcp/common/multi-ep.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+#
+# Assign up to 8 additional (advertised/subflow) addresses to the local
+# device, contiguous to $OPT_LOCAL_IP. add a signal/subflow endpoint
+# for each address added to $OPT_LOCAL_DEV
+
+usage() { echo "$0 [-e <endpoints>] [-m <signal|subflow>] [-b]" 1>&2; exit 1; }
+
+# create_endpoints <number of endpoints> <host number> <network number> <prefix length> <is_signal> <is_backup>
+create_endpoints() {
+    local host= flags= ep=1 max=$1 hn=$2 nn=$3 pl=$4 sig=${5:-0} bck=${6:-0}
+
+    [ $sig -eq 1 ] && flags=signal || flags=subflow
+    [ $bck -eq 1 ] && flags=${flags:+$flags }backup
+
+    ip mptcp endpoint flush
+    while [ ${ep} -le ${max} ]; do
+        if [ "$OPT_IP_VERSION" = "ipv6" ]; then
+            host=$(printf "%s:%x" "${nn}" "$(($(printf '%d' 0x${hn})+ep))")
+        else
+            host=${nn}$((hn+ep))
+        fi
+        ip addr add $host/$pl dev $OPT_LOCAL_DEV
+        ip mptcp endpoint add $host $flags
+        ep=$((ep+1))
+    done
+}
+
+epmax=1
+signal=1
+backup=0
+
+while getopts ":be:m:" o; do
+    case "${o}" in
+    e)
+        epmax=${OPTARG}
+        [ $epmax -ge 0 -a $epmax -le 8 ] || usage
+        ;;
+    m)
+        case ${OPTARG} in
+        signal) signal=1 ;;
+        subflow) signal=0 ;;
+        *) printf "invalid param $OPTARG\n" 1>&2 ; usage
+        esac
+        ;;
+    b)
+        backup=1
+        ;;
+    *)
+        usage
+        ;;
+    esac
+done
+shift $((OPTIND-1))
+
+if [[ $OPT_IP_VERSION = "ipv6" ]]; then
+    if [[ $OPT_LOCAL_IP =~ (.*):([0-9a-f]+) ]]; then
+        network=64
+    else
+        echo "Failed to parse ipv6 address: $OPT_LOCAL_IP" 1>&2
+        exit 1
+    fi
+
+else # ipv4 or ipv4-mapped-ipv6
+    if [[ $OPT_LOCAL_IP =~ ([0-9]+[.][0-9]+[.][0-9]+[.])([0-9]+) ]]; then
+        network=0
+        IFS=. read a b c d <<-EOF
+       `echo $OPT_LOCAL_NETMASK`
+EOF
+        for o in $d $c $b $a; do
+            case $o in
+            255) b=8 ;;
+            254) b=7 ;;
+            252) b=6 ;;
+            248) b=5 ;;
+            240) b=4 ;;
+            224) b=3 ;;
+            192) b=2 ;;
+            128) b=1 ;;
+            0)   b=0 ;;
+            *) echo "invalid value for a netmask"; exit 1 ;;
+            esac
+            if [ $b -lt 8 -a $network -gt 0 ]; then echo "ones are non-contiguous" 1>&2 ; exit 1; fi
+            network=$((network+b))
+        done
+    else
+        echo "Failed to parse ipv4 address: $OPT_LOCAL_IP"
+        exit 1
+    fi
+fi
+
+ip mptcp limits set add_addr_accepted 8 subflows 8
+create_endpoints $epmax ${BASH_REMATCH[2]} ${BASH_REMATCH[1]} $network $signal $backup

--- a/gtests/net/mptcp/fastclose/receive_fastclose_with_ack_multi.pkt
+++ b/gtests/net/mptcp/fastclose/receive_fastclose_with_ack_multi.pkt
@@ -2,7 +2,7 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-+0    `../common/server.sh`
++0    `../common/multi-ep.sh -e 0`
 
 +0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
 +0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
@@ -14,11 +14,7 @@
 +0.0    <                                .  1:1(0)        ack 1     win 256                             <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0    accept(3, ..., ...) = 4
 
-// add_addr
-+0.0    >                                .  1:1(0)        ack 1                <add_address addr[saddr1] hmac=auto, dss dack4=1                    dll=0    nocs>
-+0.0    <                                .  1:1(0)        ack 1     win 256    <add_address addr[saddr1] addr_echo, dss dack4=1                    dll=0    nocs>
-
-+0.2    <                               P.  1:1001(1000)  ack 1     win 450    <nop, nop,                           dss dack4=1    dsn8=1    ssn=1 dll=1000 nocs>
++0.2    <                               P.  1:1001(1000)  ack 1     win 450    <nop, nop,                           dss dack8=1    dsn8=1    ssn=1 dll=1000 nocs>
 +0.0    >                                .  1:1(0)        ack 1001                                                 <dss dack8=1001 nocs>
 
 +0.2    <                               P.  1:1(0)        ack 1     win 450                             <mpcapable v1 flags[flag_h] key[skey, ckey]>
@@ -26,24 +22,27 @@
 
 
 // add another subflow.
-+0.5    <  addr[caddr1] > addr[saddr1]  S   0:0(0)                  win 65535  <mss 1460, nop, wscale 7, mp_join_syn     address_id=2 token=sha256_32(skey)>
-+0.0    >                               S.  0:0(0)        ack 1                <mss 1460, nop, wscale 8, mp_join_syn_ack address_id=0 sender_hmac=auto>
++0.5    <  addr[caddr1] > addr[saddr0]  S   0:0(0)                  win 65535  <mss 1460, nop, wscale 7, mp_join_syn     address_id=1 token=sha256_32(skey)>
++0.0    >                               S.  0:0(0)        ack 1                <mss 1460, nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
 +0.0    <                                .  1:1(0)        ack 1     win 256                             <mp_join_ack                  sender_hmac=auto>
 +0.0    >                                .  1:1(0)        ack 1                          <dss dack8=1001 nocs>
 
-// send more data.
+// send more data at mptcp level.
 +0.2    <                               P.  1:1002(1001)  ack 1     win 450    <nop, nop, dss dack8=1    dsn8=1001 ssn=1 dll=1001 nocs>
-+0      >                                .  1:1(0)        ack 1002                       <dss dack8=2002                 dll=0 nocs>
++0.0    >                                .  1:1(0)        ack 1002                       <dss dack8=2002                 dll=0    nocs>
 
-// send rst fastclose.  Out of window, so it should have no effect.
-+0.1    <                               R.  3001:3001(0)            win 450              <mp_fastclose>
-+0      >                                .  1:1(0)        ack 1002                       <dss dack8=2002                 dll=0 nocs>
+// fastclose on the 2nd subflow, but old sequence numbers.
++0.1    <                                .  1:1(0)                  win 450              <mp_fastclose>
 
-// again. fastclose on the 2nd subflow.
-+0.1    <                               R.  1002:1002(0)            win 450              <mp_fastclose>
+// no effect expected.
++0.0    >                                .  1:1(0)        ack 1002                       <dss dack8=2002                 dll=0    nocs>
 
-// expect peer to reset the original flow now:
+// fastclose on the 2nd subflow, good sequence numbers.
++0.1    <                                .  1002:1002(0)            win 450              <mp_fastclose>
+
+// expect peer to reset both subflows now:
 +0.0    >  addr[saddr0] > addr[caddr0]  R.  1:1(0)        ack 1001                       <mp_reset 0>
++0.0    >  addr[saddr1] > addr[caddr1]  R.  1:1(0)        ack 1002                       <mp_reset 0>
 
 +0    read(4, ..., 2002) = 2001
 +0    close(4) = 0

--- a/gtests/net/mptcp/fastclose/receive_fastclose_with_rst_multi.pkt
+++ b/gtests/net/mptcp/fastclose/receive_fastclose_with_rst_multi.pkt
@@ -2,7 +2,7 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-+0    `../common/server.sh`
++0    `../common/multi-ep.sh -e 0`
 
 +0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
 +0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
@@ -14,11 +14,7 @@
 +0.0    <                                .  1:1(0)        ack 1     win 256                             <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0    accept(3, ..., ...) = 4
 
-// add_addr
-+0.0    >                                .  1:1(0)        ack 1                <add_address address_id=1 addr[saddr1] hmac=auto, dss dack4=1                    dll=0    nocs>
-+0.0    <                                .  1:1(0)        ack 1     win 256    <add_address address_id=1 addr[saddr1] addr_echo, dss dack4=1                    dll=0    nocs>
-
-+0.2    <                               P.  1:1001(1000)  ack 1     win 450    <nop, nop,                           dss dack8=1    dsn8=1    ssn=1 dll=1000 nocs>
++0.2    <                               P.  1:1001(1000)  ack 1     win 450    <nop, nop,                           dss dack4=1    dsn8=1    ssn=1 dll=1000 nocs>
 +0.0    >                                .  1:1(0)        ack 1001                                                 <dss dack8=1001 nocs>
 
 +0.2    <                               P.  1:1(0)        ack 1     win 450                             <mpcapable v1 flags[flag_h] key[skey, ckey]>
@@ -26,27 +22,24 @@
 
 
 // add another subflow.
-+0.5    <  addr[caddr1] > addr[saddr1]  S   0:0(0)                  win 65535  <mss 1460, nop, wscale 7, mp_join_syn     address_id=1 token=sha256_32(skey)>
-+0.0    >                               S.  0:0(0)        ack 1                <mss 1460, nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
++0.5    <  addr[caddr1] > addr[saddr0]  S   0:0(0)                  win 65535  <mss 1460, nop, wscale 7, mp_join_syn     address_id=2 token=sha256_32(skey)>
++0.0    >                               S.  0:0(0)        ack 1                <mss 1460, nop, wscale 8, mp_join_syn_ack address_id=0 sender_hmac=auto>
 +0.0    <                                .  1:1(0)        ack 1     win 256                             <mp_join_ack                  sender_hmac=auto>
 +0.0    >                                .  1:1(0)        ack 1                          <dss dack8=1001 nocs>
 
-// send more data at mptcp level.
+// send more data.
 +0.2    <                               P.  1:1002(1001)  ack 1     win 450    <nop, nop, dss dack8=1    dsn8=1001 ssn=1 dll=1001 nocs>
-+0.0    >                                .  1:1(0)        ack 1002                       <dss dack8=2002                 dll=0    nocs>
++0      >                                .  1:1(0)        ack 1002                       <dss dack8=2002                 dll=0 nocs>
 
-// fastclose on the 2nd subflow, but old sequence numbers.
-+0.1    <                                .  1:1(0)                  win 450              <mp_fastclose>
+// send rst fastclose.  Out of window, so it should have no effect.
++0.1    <                               R.  3001:3001(0)            win 450              <mp_fastclose>
++0      >                                .  1:1(0)        ack 1002                       <dss dack8=2002                 dll=0 nocs>
 
-// no effect expected.
-+0.0    >                                .  1:1(0)        ack 1002                       <dss dack8=2002                 dll=0    nocs>
+// again. fastclose on the 2nd subflow.
++0.1    <                               R.  1002:1002(0)            win 450              <mp_fastclose>
 
-// fastclose on the 2nd subflow, good sequence numbers.
-+0.1    <                                .  1002:1002(0)            win 450              <mp_fastclose>
-
-// expect peer to reset both subflows now:
+// expect peer to reset the original flow now:
 +0.0    >  addr[saddr0] > addr[caddr0]  R.  1:1(0)        ack 1001                       <mp_reset 0>
-+0.0    >  addr[saddr1] > addr[caddr1]  R.  1:1(0)        ack 1002                       <mp_reset 0>
 
 +0    read(4, ..., 2002) = 2001
 +0    close(4) = 0

--- a/gtests/net/mptcp/fastclose/receive_fastclose_with_rst_v4.pkt
+++ b/gtests/net/mptcp/fastclose/receive_fastclose_with_rst_v4.pkt
@@ -2,7 +2,8 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-+0     `../common/server.sh`
+// TODO keep using ADD_ADDR to keep test passing, until DSS values in packets 9 ~ 15 is understood
++0     `../common/multi-ep.sh -e 1 -m signal`
 
 +0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
 +0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0

--- a/gtests/net/mptcp/mp_join/mp_join_server.pkt
+++ b/gtests/net/mptcp/mp_join/mp_join_server.pkt
@@ -1,7 +1,7 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-+0    `../common/server.sh`
++0    `../common/multi-ep.sh -e 0`
 
 +0.0  socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
 +0.0  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
@@ -16,18 +16,13 @@
 +0.0    <                                .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0    accept(3, ..., ...) = 4
 
-// add_addr
-+0.0    >                                .  1:1(0)  ack 1             <nop, nop,         TS val 4074418293 ecr 4074418292, add_address address_id=1 addr[saddr1] hmac=auto, dss dack4=1 dll=0 nocs>
-+0.0    <                                .  1:1(0)  ack 1  win 256                                                        <add_address address_id=1 addr[saddr1] addr_echo, dss dack4=1 dll=0 nocs>
-
 +0.0    <                               P.  1:3(2)  ack 1  win 256    <nop, nop,         TS val 4074418292 ecr 4074410674,                mpcapable v1 flags[flag_h] key[skey, ckey] mpcdatalen 2, nop, nop>
 // MP_CAPABLE carrying data are acked with 64-bit, safer not knowing if the
 // sender will use a DSN on 64-bit or 32-bit. Later we can use the lower 32 bits
 +0.0    >                                .  1:1(0)  ack 3             <nop, nop,         TS val 4074418293 ecr 4074418292,                dss dack8=3 dll=0 nocs>
 
-
 // create subflow
-+0.0    <  addr[caddr1] > addr[saddr1]  S   0:0(0)         win 65535  <mss 1460, sackOK, TS val 448955294  ecr 0,          nop, wscale 8, mp_join_syn     backup=1 address_id=1 token=sha256_32(skey)>
++0.0    <  addr[caddr1] > addr[saddr0]  S   0:0(0)         win 65535  <mss 1460, sackOK, TS val 448955294  ecr 0,          nop, wscale 8, mp_join_syn     backup=1 address_id=1 token=sha256_32(skey)>
 +0.0    >                               S.  0:0(0)  ack 1             <mss 1460, sackOK, TS val 448955294  ecr 448955294,  nop, wscale 8, mp_join_syn_ack backup=1 address_id=1 sender_hmac=auto>
 +0.0    <                                .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 448955294  ecr 448955294,                 mp_join_ack                           sender_hmac=auto>
 

--- a/gtests/net/mptcp/mp_prio/mp_prio_server.pkt
+++ b/gtests/net/mptcp/mp_prio/mp_prio_server.pkt
@@ -1,7 +1,6 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
-
-+0    `../common/server.sh`
++0    `../common/multi-ep.sh -e 0`
 
 +0.0  socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
 +0.0  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
@@ -16,10 +15,6 @@
 +0.0    <                                .  1:1(0)        ack 1  win 256    <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0    accept(3, ..., ...) = 4
 
-// add_addr
-+0.0    >                                .  1:1(0)        ack 1             <nop, nop, TS val 4074418293 ecr 4074418292, add_address address_id=1 addr[saddr1] hmac=auto, dss dack4=1  dll=0 nocs>
-+0.0    <                                .  1:1(0)        ack 1  win 256    <                                            add_address address_id=1 addr[saddr1] addr_echo, dss dack4=1  dll=0 nocs>
-
 +0.2    <                               P.  1:3(2)        ack 1  win 256    <nop, nop, TS val 4074418292 ecr 4074410674,                        mpcapable v1 flags[flag_h] key[skey, ckey] mpcdatalen 2, nop, nop>
 // MP_CAPABLE carrying data are acked with 64-bit, safer not knowing if the
 // sender will use a DSN on 64-bit or 32-bit. Later we can use the lower 32 bits
@@ -32,7 +27,7 @@
 +0.0  read(4, ..., 2) = 2
 
 // create subflow
-+0.0    <  addr[caddr1] > addr[saddr1]  S   0:0(0)               win 65535  <mss 1460, sackOK, TS val 448955294 ecr 0,         nop, wscale 8, mp_join_syn     backup=1 address_id=1 token=sha256_32(skey)>
++0.0    <  addr[caddr1] > addr[saddr0]  S   0:0(0)               win 65535  <mss 1460, sackOK, TS val 448955294 ecr 0,         nop, wscale 8, mp_join_syn     backup=1 address_id=1 token=sha256_32(skey)>
 +0.0    >                               S.  0:0(0)        ack 1             <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack backup=1 address_id=0 sender_hmac=auto>
 +0.0    <                                .  1:1(0)        ack 1  win 256    <nop, nop, TS val 448955294 ecr 448955294,                        mp_join_ack sender_hmac=auto>
 +0.0    >                                .  1:1(0)        ack 1             <nop, nop, TS val 448955294 ecr 448955294,                        dss dack4=5 nocs>

--- a/gtests/net/mptcp/mp_reset/mp_reset_multi.pkt
+++ b/gtests/net/mptcp/mp_reset/mp_reset_multi.pkt
@@ -2,7 +2,7 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-+0    `../common/server.sh`
++0    `../common/multi-ep.sh -e 0`
 
 +0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
 +0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
@@ -14,10 +14,6 @@
 +0.0    <                                .  1:1(0)           ack 1     win 256                             <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0    accept(3, ..., ...) = 4
 
-// add_addr
-+0.0    >                                .  1:1(0)           ack 1                <add_address addr[saddr1] hmac=auto, dss dack4=1                       dll=0    nocs>
-+0.0    <                                .  1:1(0)           ack 1     win 256    <add_address addr[saddr1] addr_echo, dss dack4=1                       dll=0    nocs>
-
 +0.2    <                               P.  1:1001(1000)     ack 1     win 450    <nop, nop,                           dss dack8=1    dsn8=1    ssn=1    dll=1000 nocs>
 +0.0    >                                .  1:1(0)           ack 1001                                                 <dss dack8=1001 nocs>
 
@@ -25,7 +21,7 @@
 +0.0    >                                .  1:1(0)           ack 1001                                                 <dss dack8=1001 nocs>
 
 // add another subflow.
-+0.5    <  addr[caddr1] > addr[saddr1]  S   0:0(0)                     win 65535  <mss 1460, nop, wscale 7, mp_join_syn     address_id=2 token=sha256_32(skey)>
++0.5    <  addr[caddr1] > addr[saddr0]  S   0:0(0)                     win 65535  <mss 1460, nop, wscale 7, mp_join_syn     address_id=2 token=sha256_32(skey)>
 +0.0    >                               S.  0:0(0)           ack 1                <mss 1460, nop, wscale 8, mp_join_syn_ack address_id=0 sender_hmac=auto>
 +0.0    <                                .  1:1(0)           ack 1     win 256                             <mp_join_ack                  sender_hmac=auto>
 +0.0    >                                .  1:1(0)           ack 1                                                    <dss dack8=1001 nocs>

--- a/gtests/net/mptcp/syscalls/accept.pkt
+++ b/gtests/net/mptcp/syscalls/accept.pkt
@@ -1,7 +1,7 @@
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
-+0    `../common/server.sh`
++0    `../common/multi-ep.sh -e 0`
 
 +0.0  socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
 +0.0  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
@@ -16,17 +16,13 @@
 +0.0    <                                .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0    accept(3, ..., ...) = 4
 
-// add_addr
-+0.0    >                                .  1:1(0)  ack 1             <nop, nop,         TS val 4074418293 ecr 4074418292, add_address addr[saddr1] hmac=auto, dss dack4=1 dll=0 nocs>
-+0.0    <                                .  1:1(0)  ack 1  win 256                                                        <add_address addr[saddr1] addr_echo, dss dack4=1 dll=0 nocs>
-
 +0.2    <                               P.  1:3(2)  ack 1  win 256    <nop, nop,         TS val 4074418292 ecr 4074410674,                mpcapable v1 flags[flag_h] key[skey, ckey] mpcdatalen 2, nop, nop>
 // MP_CAPABLE carrying data are acked with 64-bit, safer not knowing if the
 // sender will use a DSN on 64-bit or 32-bit. Later we can use the lower 32 bits
 +0.0    >                                .  1:1(0)  ack 3             <nop, nop,         TS val 4074418293 ecr 4074418292,                dss dack8=3 dll=0 nocs>
 
 // create subflow
-+0.0    <  addr[caddr1] > addr[saddr1]  S   0:0(0)         win 65535  <mss 1460, sackOK, TS val 448955294  ecr 0,          nop, wscale 8, mp_join_syn     backup=1 address_id=2 token=sha256_32(skey)>
++0.0    <  addr[caddr1] > addr[saddr0]  S   0:0(0)         win 65535  <mss 1460, sackOK, TS val 448955294  ecr 0,          nop, wscale 8, mp_join_syn     backup=1 address_id=2 token=sha256_32(skey)>
 +0.0    >                               S.  0:0(0)  ack 1             <mss 1460, sackOK, TS val 448955294  ecr 448955294,  nop, wscale 8, mp_join_syn_ack backup=1 address_id=0 sender_hmac=auto>
 +0.0    <                                .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 448955294  ecr 448955294,                 mp_join_ack                           sender_hmac=auto>
 +0.0    >                                .  1:1(0)  ack 1             <nop, nop,         TS val 448955294  ecr 448955294,                 dss dack8=3 nocs>


### PR DESCRIPTION
* convert server scripts using more than 1 subflow to avoid using `ADD_ADDR`. Let packetdrill core create the endpoint when the inbound `MP_JOIN SYN` is parsed.
* remove the `_v4` suffix from those scripts, so that `run_all.py` does IPv6 testing over them

Closes: https://github.com/multipath-tcp/mptcp_net-next/issues/143