### PR TITLE
Update kernel config for AF_ALG usage

### DIFF
--- a/gtests/net/packetdrill/packetdrill.config
+++ b/gtests/net/packetdrill/packetdrill.config
@@ -3,3 +3,7 @@
 # ./scripts/kconfig/merge_config.sh -m .config packetdrill.config
 
 CONFIG_TUN=y
+
+CONFIG_CRYPTO_SHA1=y
+CONFIG_CRYPTO_SHA256=y
+CONFIG_CRYPTO_USER_API_HASH=y


### PR DESCRIPTION
mptcp_utils.c uses AF_ALG sockets for SHA1 and SHA256 hashes, so the
kernel under test needs a few kernel config options to support those.

Signed-off-by: Mat Martineau <mathew.j.martineau@linux.intel.com>