### PR TITLE
mptcp: update self-test after kernel behavior change

### DIFF
--- a/gtests/net/mptcp/add_addr/add_addr4_port_client.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr4_port_client.pkt
@@ -18,5 +18,5 @@
 +0.205  fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
 
 // ADD_ADDRESS with port
-+0.0      <   .  1:1(0)  ack 1  win 256                                                         <add_address address_id=12 addr[ep=inet_addr("198.51.100.2")] port=4321 hmac=auto, dss dack4=1 dll=0 nocs, nop, nop>
++0.0      <   .  1:1(0)  ack 1  win 256                                                         <add_address address_id=12 addr[ep=inet_addr("198.51.100.2")] port=4321 hmac=auto, nop, nop>
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,          TS val 100 ecr 700,               add_address address_id=12 addr[ep=inet_addr("198.51.100.2")] port=4321 addr_echo, nop, nop>

--- a/gtests/net/mptcp/add_addr/add_addr4_server.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr4_server.pkt
@@ -17,8 +17,8 @@
 +0     accept(3, ..., ...) = 4
 
 // ADD_ADDR is sent directly (>= 5.12), not after first data (< 5.12)
-+0       >   .  1:1(0)        ack 1              <add_address address_id=1 addr[ep=inet_addr("198.51.100.2")] hmac=auto, dss dack4=1 ssn=1 dll=0 nocs>
-+0       <   .  1:1(0)        ack 1     win 257  <add_address address_id=1 addr[ep=inet_addr("198.51.100.2")] addr_echo, dss dack4=1 ssn=1 dll=0 nocs>
++0       >   .  1:1(0)        ack 1              <add_address address_id=1 addr[ep=inet_addr("198.51.100.2")] hmac=auto>
++0       <   .  1:1(0)        ack 1     win 257  <add_address address_id=1 addr[ep=inet_addr("198.51.100.2")] addr_echo>
 
 // read and ack 1 data segment
 +0.1     <  P.  1:1001(1000)  ack 1     win 450  <nop, nop,                          dss dack8=1    dsn8=1 ssn=1 dll=1000 nocs>

--- a/gtests/net/mptcp/fastclose/receive_fastclose_with_rst_v4.pkt
+++ b/gtests/net/mptcp/fastclose/receive_fastclose_with_rst_v4.pkt
@@ -15,6 +15,11 @@
 +0.0     <                                .  1:1(0)           ack 1     win 256                              <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
 
+// the 4th ack, making the mptcp socket fully established, will trigger the add_addr
++0.0     <                                .  1:1(0)           ack 1     win 256                                         <dss dack4=1 nocs>
++0.0     >                                .  1:1(0)           ack 1                <add_address addr[saddr1] hmac=auto>
++0.0     <                                .  1:1(0)           ack 1     win 256    <add_address addr[saddr1] addr_echo,  dss dack4=1 nocs>
+
 +0.0     <                               P.  1:1001(1000)     ack 1     win 450    <nop, nop,                 dss dack8=1    dsn8=1    ssn=1    dll=1000 nocs>
 +0.0     >                                .  1:1(0)           ack 1001                                       <dss dack8=1001 nocs>
 
@@ -29,9 +34,7 @@
 +0.1     <  addr[caddr0] > addr[saddr0]  S   0:0(0)                      win 65535  <mss 1460, nop, wscale 7, mp_join_syn     address_id=0 token=sha256_32(skey)>
 +0.0     >                               S.  0:0(0)           ack 1                 <mss 1460, nop, wscale 8, mp_join_syn_ack address_id=0 sender_hmac=auto>
 +0.0     <                                .  1:1(0)           ack 1      win 256                             <mp_join_ack                  sender_hmac=auto>
-
-+0.0     >                                .  1:1(0)           ack 1                 <add_address addr[saddr1] hmac=auto, dss dack8=1001 nocs>
-+0.0     <                                .  1:1(0)           ack 1      win 256    <add_address addr[saddr1] addr_echo, dss dack8=1    nocs>
++0.0     >                                .  1:1(0)           ack 1                 <dss dack8=1001 nocs>
 
 // more data, resend.  should work now.
 +0.0     <                               P.  1:1001(1000)     ack 1      win 450    <nop, nop,                           dss dack8=1    dsn8=1001 ssn=1    dll=1000 nocs>


### PR DESCRIPTION
after the last incarnation of commit "mptcp: move
drop_other_suboptions check under pm lock", ADD_ADDR v4 never
carries a DSS, update the self-test accordingly

Side note: the fastclose self-test required some more mangling
and dropping the 'dss dack4=1 nocs' opt from the injected packet
causes an internal error, which is likely worth fixing independently

Signed-off-by: Paolo Abeni <pabeni@redhat.com>