### PR TITLE
mptcp: mpc with OoO: fix code style

### DIFF
--- a/gtests/net/mptcp/mp_capable/v1_mp_capable_bind_no_cs_ooo.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_mp_capable_bind_no_cs_ooo.pkt
@@ -8,7 +8,8 @@
 +0     bind(3, ..., ...) = 0
 +0     listen(3, 1) = 0
 
-+0       <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
-+0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.01    <   .  101:201(100)   ack 1  win 257       <mpcapable v1 flags[flag_h] key[ckey=2, skey] mpcdatalen 200, nop, nop>
-+0       >   .  1:1(0)         ack 1      <nop, nop, sack 101:201, dss dack4=1 nocs>
++0       <  S   0:0(0)               win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0       >  S.  0:0(0)        ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.01    <   .  101:201(100)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey] mpcdatalen 200, nop, nop>
+
++0       >   .  1:1(0)        ack 1             <nop, nop, sack 101:201, dss dack4=1 nocs>


### PR DESCRIPTION
Just to follow the code style used in other files.

Signed-off-by: Matthieu Baerts <matthieu.baerts@tessares.net>