### PR TITLE
mptcp: fix missing dash in the new sockopts test

### DIFF
--- a/gtests/net/mptcp/sockopts/mptcp_unsupported_sockopts_tcp_inq.pkt
+++ b/gtests/net/mptcp/sockopts/mptcp_unsupported_sockopts_tcp_inq.pkt
@@ -1,4 +1,4 @@
--tolerance_usecs=100000
+--tolerance_usecs=100000
 `../../common/defaults.sh`
 
 // test 1 : TCP_INQ is not supported by MPTCP sockets yet.


### PR DESCRIPTION
The error:

    mptcp_unsupported_sockopts_tcp_inq.pkt:1: parse error at '-': syntax error

Signed-off-by: Matthieu Baerts <matthieu.baerts@tessares.net>