### PR TITLE
mptcp: unsupported sockopts return ENOPROTOOPT errno

### DIFF
--- a/gtests/net/mptcp/sockopts/mptcp_unsupported_sockopts_tcp_inq.pkt
+++ b/gtests/net/mptcp/sockopts/mptcp_unsupported_sockopts_tcp_inq.pkt
@@ -4,5 +4,5 @@
 // test 1 : TCP_INQ is not supported by MPTCP sockets yet.
 // Follow https://github.com/multipath-tcp/mptcp_net-next/issues/224 for progress
 0.0   socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
-+0.0  setsockopt(3, SOL_TCP, TCP_INQ, [1], 4) = -1 EOPNOTSUPP (Operation not supported)
++0.0  setsockopt(3, SOL_TCP, TCP_INQ, [1], 4)   = -1 ENOPROTOOPT (Protocol not available)
 +0.0  getsockopt(3, SOL_TCP, TCP_INQ, [0], [4]) = -1 EOPNOTSUPP (Operation not supported)


### PR DESCRIPTION
Only for the setsockopt() part.

For the getsockopt() part, EOPNOTSUPP is returned.

That's maybe not consistent but that's the current behaviour.

Signed-off-by: Matthieu Baerts <matthieu.baerts@tessares.net>