### PR TITLE
Fix cirrus ci failures

### DIFF
--- a/gtests/net/mptcp/add_addr/add_addr_retry_v4.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr_retry_v4.pkt
@@ -16,13 +16,13 @@
 +0     accept(3, ..., ...) = 4
 
 // ADD_ADDR is sent directly (>= 5.12), not after first data (< 5.12)
-+0       >   .  1:1(0)        ack 1           <add_address address_id=1  addr[saddr0] hmac=auto,                  dss dack4=1 ssn=1 dll=0 nocs>
++0       >   .  1:1(0)        ack 1           <add_address address_id=1  addr[saddr0] hmac=auto>
 // send echo with wrong address, expect a retry in 1s
 +0       <   .  1:1(0)        ack 1  win 257  <add_address address_id=1  addr[ep=inet_addr("1.2.3.4")] addr_echo, dss dack4=1 ssn=1 dll=0 nocs>
-+1.0     >   .  1:1(0)        ack 1           <add_address address_id=1  addr[saddr0] hmac=auto,                  dss dack4=1 ssn=1 dll=0 nocs>
++1.0     >   .  1:1(0)        ack 1           <add_address address_id=1  addr[saddr0] hmac=auto>
 // send echo with wrong id, expect a retry in 1s
 +0       <   .  1:1(0)        ack 1  win 257  <add_address address_id=90 addr[saddr0] addr_echo>
-+1.0     >   .  1:1(0)        ack 1           <add_address address_id=1  addr[saddr0] hmac=auto,                  dss dack4=1 ssn=1 dll=0 nocs>
++1.0     >   .  1:1(0)        ack 1           <add_address address_id=1  addr[saddr0] hmac=auto>
 // send echo with correct id, expect no retry
 +0       <   .  1:1(0)        ack 1  win 257  <add_address address_id=1  addr[saddr0] addr_echo>
 // read and ack 1 data segment


### PR DESCRIPTION
patchew + cirrus CI reports the following failure:
```
  stderr:
 # add_addr_retry_v4.pkt:19: error handling packet: live packet field ipv4_total_length: expected: 64 (0x40) vs actual: 56 (0x38)
 # script packet:  0.729882 . 1:1(0) ack 1 <add_address address_id: 1 ipv4: 192.168.0.3 hmac: 5034739091514653373,dss dack4 16777216 flags: A>
 # actual packet:  0.729909 . 1:1(0) ack 1 win 256 <add_address address_id: 1 ipv4: 192.168.0.3 hmac: 5034739091514653373>
```
Fix it removing DSS from outbound ADD_ADDR: Linux does not send them
anymore since ADD_ADDR are pure TCP ACKs.

see also: https://github.com/multipath-tcp/mptcp_net-next/runs/3700661580

Signed-off-by: Davide Caratti <dcaratti@redhat.com>