### PR TITLE
Revert "re-center the timeout for ADD_ADDR retries"

### DIFF
--- a/gtests/net/mptcp/add_addr/add_addr_retry_v4.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr_retry_v4.pkt
@@ -19,10 +19,10 @@
 +0       >   .  1:1(0)        ack 1           <add_address address_id=1  addr[saddr0] hmac=auto>
 // send echo with wrong address, expect a retry in 1s
 +0       <   .  1:1(0)        ack 1  win 257  <add_address address_id=1  addr[ep=inet_addr("1.2.3.4")] addr_echo, dss dack4=1 ssn=1 dll=0 nocs>
-+0.75    >   .  1:1(0)        ack 1           <add_address address_id=1  addr[saddr0] hmac=auto>
++1.0     >   .  1:1(0)        ack 1           <add_address address_id=1  addr[saddr0] hmac=auto>
 // send echo with wrong id, expect a retry in 1s
 +0       <   .  1:1(0)        ack 1  win 257  <add_address address_id=90 addr[saddr0] addr_echo>
-+0.75    >   .  1:1(0)        ack 1           <add_address address_id=1  addr[saddr0] hmac=auto>
++1.0     >   .  1:1(0)        ack 1           <add_address address_id=1  addr[saddr0] hmac=auto>
 // send echo with correct id, expect no retry
 +0       <   .  1:1(0)        ack 1  win 257  <add_address address_id=1  addr[saddr0] addr_echo>
 // read and ack 1 data segment


### PR DESCRIPTION
This reverts commit a6a9435216ca707840adce38989e6f4c071a6bd6.

Reverts multipath-tcp/packetdrill#68

The modification causes some issues on "not slow environments":

If we have:

    1:  t=0  >  ADD_ADDR
    2:  t=0  <  bad echo ADD_ADDR → immediately after (1)
    3:  t=1  >  retransmit ADD_ADDR

The time difference between (2) and (3) is 1 second which is more than
0.75 (script) + 0.2 (tolerance).

As proven by:

    # add_addr_retry_v4.pkt:22: error handling packet: timing error: expected outbound packet at 0.949773 sec but happened at 1.251941 sec; tolerance 0.200000 sec
    # script packet:  0.949773 . 1:1(0) ack 1 <add_address address_id: 1 ipv4: 192.168.0.3 hmac: 17198050779130180692>
    # actual packet:  1.251941 . 1:1(0) ack 1 win 256 <add_address address_id: 1 ipv4: 192.168.0.3 hmac: 17198050779130180692>

Instead, we can properly increase the tolerance on CIs with a non debug
kernel as now done by the scripts, see:

    https://github.com/multipath-tcp/mptcp-upstream-virtme-docker/commit/0de7198

Signed-off-by: Matthieu Baerts <matthieu.baerts@tessares.net>