### PR TITLE
mptcp: Add coverage for setsockopt(SOL_IP, IP_TOS)

### DIFF
--- a/gtests/net/mptcp/sockopts/sockopt_set_ip_tos_invalid.pkt
+++ b/gtests/net/mptcp/sockopts/sockopt_set_ip_tos_invalid.pkt
@@ -1,0 +1,36 @@
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
++0    `../common/client.sh`
+
++0.0  socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 7
++0.0  setsockopt(7, SOL_IP, IP_TOS, [7], 4) = 0
++0.0  fcntl(7, F_GETFL) = 0x2 (flags O_RDWR)
++0.0  fcntl(7, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+
++0.0  connect(7, ..., ...) = -1  EINPROGRESS (Operation now in progress)
+
++0.0  >  [tos 0x04]  addr[caddr0] > addr[saddr0]  S   0:0(0)                    <mss 1460, sackOK, TS val 4074410674 ecr 0,          nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++0.0  <                                           S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.0  >  [tos 0x04]                                .  1:1(0)  ack 1             <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey, skey]>
+
++0.0  fcntl(7, F_SETFL, O_RDWR) = 0   // set back to blocking
++0.2  setsockopt(7, SOL_IP, IP_TOS, [7], 4) = 0
++1.0  write(7, ..., 2) = 2
+
++0.0  >  [tos 0x04]                               P.  1:3(2)  ack 1             <nop, nop,         TS val 4074418292 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey, skey] mpcdatalen 2, nop, nop>
++0.0  <                                            .  1:1(0)  ack 3  win 256    <nop, nop,         TS val 4074418293 ecr 4074418292, add_address addr[saddr1] hmac=auto>
+
++0.0  setsockopt(7, SOL_IP, IP_TOS, [7], 4) = 0
+
++0.0  >  [tos 0x04]               > addr[saddr1]  S   0:0(0)                    <mss 1460, sackOK, TS val 448955294 ecr 0,         nop, wscale 8, mp_join_syn     address_id=0 token=sha256_32(skey)>
++0.0  >  [tos 0x04]               > addr[saddr0]   .  3:3(0)  ack 1             <nop, nop,         TS val 448955294 ecr 448955294,   add_address addr[saddr1] addr_echo>
++0.0  <                                           S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
++0.0  >  [tos 0x04]                                .  1:1(0)  ack 1             <nop, nop,         TS val 448955294 ecr 448955294,                mp_join_ack                  sender_hmac=auto>
+
++0.0  setsockopt(7, SOL_IP, IP_TOS, [7], 4) = 0
++0.1  close(7) = 0
+
++0.0  >  [tos 0x04]  addr[caddr0] > addr[saddr0]   .  3:3(0)  ack 1  win 256    <nop, nop,         TS val 4074418292 ecr 4074418293, dss dack4=1 dsn8=3 ssn=0 dll=1 nocs fin, nop, nop>
++0.0  >  [tos 0x04]                                .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 4074418292 ecr 4074418293, dss dack4=1 dsn8=3 ssn=0 dll=1 nocs fin, nop, nop>
+

--- a/gtests/net/mptcp/sockopts/sockopt_set_ip_tos_valid.pkt
+++ b/gtests/net/mptcp/sockopts/sockopt_set_ip_tos_valid.pkt
@@ -1,0 +1,36 @@
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
++0    `../common/client.sh`
+
++0.0  socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 7
++0.0  setsockopt(7, SOL_IP, IP_TOS, [4], 4) = 0
++0.0  fcntl(7, F_GETFL) = 0x2 (flags O_RDWR)
++0.0  fcntl(7, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+
++0.0  connect(7, ..., ...) = -1  EINPROGRESS (Operation now in progress)
+
++0.0  >  [tos 0x04]  addr[caddr0] > addr[saddr0]  S   0:0(0)                    <mss 1460, sackOK, TS val 4074410674 ecr 0,          nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++0.0  <                                           S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.0  >  [tos 0x04]                                .  1:1(0)  ack 1             <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey, skey]>
+
++0.0  fcntl(7, F_SETFL, O_RDWR) = 0   // set back to blocking
++0.2  setsockopt(7, SOL_IP, IP_TOS, [4], 4) = 0
++1.0  write(7, ..., 2) = 2
+
++0.0  >  [tos 0x04]                               P.  1:3(2)  ack 1             <nop, nop,         TS val 4074418292 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey, skey] mpcdatalen 2, nop, nop>
++0.0  <                                            .  1:1(0)  ack 3  win 256    <nop, nop,         TS val 4074418293 ecr 4074418292, add_address addr[saddr1] hmac=auto>
+
++0.0  setsockopt(7, SOL_IP, IP_TOS, [7], 4) = 0
+
++0.0  >  [tos 0x04]              > addr[saddr1]   S   0:0(0)                    <mss 1460, sackOK, TS val 448955294 ecr 0,         nop, wscale 8, mp_join_syn     address_id=0 token=sha256_32(skey)>
++0.0  >  [tos 0x04]              > addr[saddr0]    .  3:3(0)  ack 1             <nop, nop,         TS val 448955294 ecr 448955294,   add_address addr[saddr1] addr_echo>
++0.0  <                                           S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
++0.0  >  [tos 0x04]                                .  1:1(0)  ack 1             <nop, nop,         TS val 448955294 ecr 448955294,                mp_join_ack                  sender_hmac=auto>
+
++0.0  setsockopt(7, SOL_IP, IP_TOS, [4], 4) = 0
++0.1  close(7) = 0
+
++0.0  >  [tos 0x04]  addr[caddr0] > addr[saddr0]   .  3:3(0)  ack 1  win 256    <nop, nop,         TS val 4074418292 ecr 4074418293, dss dack4=1 dsn8=3 ssn=0 dll=1 nocs fin, nop, nop>
++0.0  >  [tos 0x04]                                .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 4074418292 ecr 4074418293, dss dack4=1 dsn8=3 ssn=0 dll=1 nocs fin, nop, nop>
+


### PR DESCRIPTION
Since support for setsockopt(SOL_IP, IP_TOS), this packetdrill test
provides coverage for setsockopt(SOL_IP, IP_TOS) and assesses it's behavior.
There are currently two tests to check if TOS value is being set - one with
TOS as 4 and other with TOS as 7. The expected behaviour is that in both cases
the outbound packet should have TOS set as 4.
The scripts also test if the value of TOS is set for new subflows created after
setsockopt() is called.

Closes: https://github.com/multipath-tcp/mptcp_net-next/issues/238

Signed-off-by: Poorva Sonparote <psonparo@redhat.com>