### PR TITLE
mptcp: TCP_INQ is now supported 

### DIFF
--- a/gtests/net/mptcp/sockopts/mptcp_unsupported_sockopts.pkt
+++ b/gtests/net/mptcp/sockopts/mptcp_unsupported_sockopts.pkt
@@ -1,0 +1,7 @@
+--tolerance_usecs=100000
+`../../common/defaults.sh`
+
+// TCP_MD5SIG is not supported by MPTCP sockets and will never be.
+0.0   socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0  setsockopt(3, SOL_TCP, TCP_MD5SIG, [1], 4)   = -1 ENOPROTOOPT (Protocol not available)
++0.0  getsockopt(3, SOL_TCP, TCP_MD5SIG, [0], [4]) = -1 EOPNOTSUPP (Operation not supported)

--- a/gtests/net/mptcp/sockopts/mptcp_unsupported_sockopts_tcp_inq.pkt
+++ b/gtests/net/mptcp/sockopts/mptcp_unsupported_sockopts_tcp_inq.pkt
@@ -1,8 +1,0 @@
---tolerance_usecs=100000
-`../../common/defaults.sh`
-
-// test 1 : TCP_INQ is not supported by MPTCP sockets yet.
-// Follow https://github.com/multipath-tcp/mptcp_net-next/issues/224 for progress
-0.0   socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
-+0.0  setsockopt(3, SOL_TCP, TCP_INQ, [1], 4)   = -1 ENOPROTOOPT (Protocol not available)
-+0.0  getsockopt(3, SOL_TCP, TCP_INQ, [0], [4]) = -1 EOPNOTSUPP (Operation not supported)


### PR DESCRIPTION
Use TCP_MD5SIG instead: this one is not supported and will never be.

We can then keep a test checking we continue to report the proper errors when a sockopt is not supported.