### PR TITLE
DO NOT MERGE: run_all: capture packet per test

### DIFF
--- a/gtests/net/packetdrill/in_netns.sh
+++ b/gtests/net/packetdrill/in_netns.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Execute a subprocess in a network namespace
 
@@ -6,12 +6,22 @@ set -e
 
 readonly NETNS="ns-$(mktemp -u XXXXXX)"
 
+# last arg is the file name
+for i in "${@}"; do pkt="${i}"; done
+for i in "${@}"; do [[ "${i}" = "--ip_version="* ]] && ipv="${i#*=}"; done
+OUTPUT="${HOME}/${pkt}_${ipv}.pcap"
+PID=
+
 setup() {
 	ip netns add "${NETNS}"
 	ip -netns "${NETNS}" link set lo up
+	ip netns exec "${NETNS}" tcpdump -i any -s 150 -w "${OUTPUT}" &
+	PID=$!
+	sleep 1
 }
 
 cleanup() {
+	kill ${PID}
 	ip netns del "${NETNS}"
 }
 


### PR DESCRIPTION
This is useful for debug purposes.

It is useful to have traces for academic researches. This script helped to capture traces of all MPTCP packetdrill scripts: [traces.tar.gz](https://github.com/multipath-tcp/packetdrill/files/7958963/traces.tar.gz)

We should not merge this, only useful for debug. It could be extended to turn on the capture on demand but that's not the goal here.

Signed-off-by: Matthieu Baerts <matthieu.baerts@tessares.net>