### PR TITLE
fix missing address_id in the inbound echoed ADD_ADDR

### DIFF
--- a/gtests/net/mptcp/fastclose/receive_fastclose_with_rst_v4.pkt
+++ b/gtests/net/mptcp/fastclose/receive_fastclose_with_rst_v4.pkt
@@ -17,8 +17,8 @@
 
 // the 4th ack, making the mptcp socket fully established, will trigger the add_addr
 +0.0     <                                .  1:1(0)           ack 1     win 256                                         <dss dack4=1 nocs>
-+0.0     >                                .  1:1(0)           ack 1                <add_address addr[saddr1] hmac=auto>
-+0.0     <                                .  1:1(0)           ack 1     win 256    <add_address addr[saddr1] addr_echo,  dss dack4=1 nocs>
++0.0     >                                .  1:1(0)           ack 1                <add_address address_id=1 addr[saddr1] hmac=auto>
++0.0     <                                .  1:1(0)           ack 1     win 256    <add_address address_id=1 addr[saddr1] addr_echo,  dss dack4=1 nocs>
 
 +0.0     <                               P.  1:1001(1000)     ack 1     win 450    <nop, nop,                 dss dack8=1    dsn8=1    ssn=1    dll=1000 nocs>
 +0.0     >                                .  1:1(0)           ack 1001                                       <dss dack8=1001 nocs>


### PR DESCRIPTION
otherwise packetdrill won't be able to fill "id" and "address". While at it,
improve the validation of the outbound ADD_ADDR by checking the 'address_id'
value (that is 1, since multi-ep.sh is always executed in a freshly-created
namespace).

Closes: https://github.com/multipath-tcp/mptcp_net-next/issues/245
Signed-off-by: Davide Caratti <dcaratti@redhat.com>