### PR TITLE
Adaptive send ADD_ADDR echo before create subflows

### DIFF
--- a/gtests/net/mptcp/mp_join/3rdack_rtx.pkt
+++ b/gtests/net/mptcp/mp_join/3rdack_rtx.pkt
@@ -18,12 +18,12 @@
 
 +1.0  write(3, ..., 2) = 2
 +0.0    >                               P.  1:3(2)      ack 1             <nop, nop,         TS val 407418292 ecr 4074410674,                 mpcapable v1 flags[flag_h] key[ckey, skey] mpcdatalen 2, nop, nop>
-+0.0    <                                .  1:1(0)      ack 3  win 256    <nop, nop,         TS val 407441893 ecr 407418292, add_address addr[saddr1] hmac=auto>
-+0.0    <                                .  1:1(0)      ack 3  win 256                      <TS val 407441893 ecr 407418292, dss dack8=3   dsn8=1 nocs>
++0.0    <                                .  1:1(0)      ack 3  win 256    <nop, nop,         TS val 407441893 ecr 407418292,  add_address addr[saddr1] hmac=auto>
++0.0    >                                .  3:3(0)      ack 1             <nop, nop,         TS val 407418294 ecr 4074410674, add_address addr[saddr1] addr_echo>
++0.0    <                                .  1:1(0)      ack 3  win 256                      <TS val 407441893 ecr 407418292,  dss dack8=3   dsn8=1 nocs>
 
 
 +0.0    >               > addr[saddr1]  S   0:0(0)                        <mss 1460, sackOK, TS val 448955294 ecr 0,         nop, wscale 8, mp_join_syn     address_id=0 token=sha256_32(skey)>
-+0.0    >               > addr[saddr0]   .  3:3(0)      ack 1             <nop, nop,         TS val 448955294 ecr 448955294, add_address addr[saddr1] addr_echo>
 
 // introduce a measurable rtt, so we can guess the rtx time
 +0.2    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>

--- a/gtests/net/mptcp/mp_join/mp_join_client.pkt
+++ b/gtests/net/mptcp/mp_join/mp_join_client.pkt
@@ -19,10 +19,10 @@
 +1.0  write(3, ..., 2) = 2
 +0.0    >                               P.  1:3(2)      ack 1             <nop, nop, TS val 4074418292 ecr 4074410674,                        mpcapable v1 flags[flag_h] key[ckey, skey] mpcdatalen 2, nop, nop>
 +0.0    <                                .  1:1(0)      ack 3  win 256    <nop, nop, TS val 4074418293 ecr 4074418292,       add_address addr[saddr1] hmac=auto>
++0.0    >                                .  3:3(0)      ack 1             <nop, nop, TS val 4074418294 ecr 4074410674,       add_address addr[saddr1] addr_echo>
 
 
 +0.0    >               > addr[saddr1]  S   0:0(0)                        <mss 1460, sackOK, TS val 448955294 ecr 0,         nop, wscale 8, mp_join_syn     address_id=0 token=sha256_32(skey)>
-+0.0    >               > addr[saddr0]   .  3:3(0)      ack 1             <nop, nop,         TS val 448955294 ecr 448955294, add_address addr[saddr1] addr_echo>
 +0.0    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
 +0.0    >                                .  1:1(0)      ack 1             <nop, nop,         TS val 448955294 ecr 448955294,                mp_join_ack                  sender_hmac=auto>
 

--- a/gtests/net/mptcp/sockopts/sockopt_set_ip_tos_invalid_v4.pkt
+++ b/gtests/net/mptcp/sockopts/sockopt_set_ip_tos_invalid_v4.pkt
@@ -20,11 +20,11 @@
 
 +0.0  >  [tos 0x04]                               P.  1:3(2)  ack 1             <nop, nop,         TS val 4074418292 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey, skey] mpcdatalen 2, nop, nop>
 +0.0  <                                            .  1:1(0)  ack 3  win 256    <nop, nop,         TS val 4074418293 ecr 4074418292, add_address addr[saddr1] hmac=auto>
++0.0  >  [tos 0x04]                                .  3:3(0)  ack 1             <nop, nop,         TS val 4074418294 ecr 4074410674, add_address addr[saddr1] addr_echo>
 
 +0.0  setsockopt(7, SOL_IP, IP_TOS, [7], 4) = 0
 
 +0.0  >  [tos 0x04]               > addr[saddr1]  S   0:0(0)                    <mss 1460, sackOK, TS val 448955294 ecr 0,         nop, wscale 8, mp_join_syn     address_id=0 token=sha256_32(skey)>
-+0.0  >  [tos 0x04]               > addr[saddr0]   .  3:3(0)  ack 1             <nop, nop,         TS val 448955294 ecr 448955294,   add_address addr[saddr1] addr_echo>
 +0.0  <                                           S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
 +0.0  >  [tos 0x04]                                .  1:1(0)  ack 1             <nop, nop,         TS val 448955294 ecr 448955294,                mp_join_ack                  sender_hmac=auto>
 +0.0  <                                            .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 448955294 ecr 448955294,   dss dack8=3   nocs>

--- a/gtests/net/mptcp/sockopts/sockopt_set_ip_tos_valid_v4.pkt
+++ b/gtests/net/mptcp/sockopts/sockopt_set_ip_tos_valid_v4.pkt
@@ -20,11 +20,11 @@
 
 +0.0  >  [tos 0x04]                               P.  1:3(2)  ack 1             <nop, nop,         TS val 4074418292 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey, skey] mpcdatalen 2, nop, nop>
 +0.0  <                                            .  1:1(0)  ack 3  win 256    <nop, nop,         TS val 4074418293 ecr 4074418292, add_address addr[saddr1] hmac=auto>
++0.0  >  [tos 0x04]                                .  3:3(0)  ack 1             <nop, nop,         TS val 4074418294 ecr 4074410674, add_address addr[saddr1] addr_echo>
 
 +0.0  setsockopt(7, SOL_IP, IP_TOS, [7], 4) = 0
 
 +0.0  >  [tos 0x04]               > addr[saddr1]  S   0:0(0)                    <mss 1460, sackOK, TS val 448955294 ecr 0,         nop, wscale 8, mp_join_syn     address_id=0 token=sha256_32(skey)>
-+0.0  >  [tos 0x04]               > addr[saddr0]   .  3:3(0)  ack 1             <nop, nop,         TS val 448955294 ecr 448955294,   add_address addr[saddr1] addr_echo>
 +0.0  <                                           S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
 +0.0  >  [tos 0x04]                                .  1:1(0)  ack 1             <nop, nop,         TS val 448955294 ecr 448955294,                mp_join_ack                  sender_hmac=auto>
 +0.0  <                                            .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 448955294 ecr 448955294,   dss dack8=3   nocs>

--- a/gtests/net/packetdrill/mptcp.c
+++ b/gtests/net/packetdrill/mptcp.c
@@ -1830,7 +1830,8 @@ static struct endpoint *find_next_addr_outbound(struct packet *live_packet, stru
 	   add_addr_script->length == TCPOLEN_ADD_ADDR_V6_HMAC){
 		struct tuple tuple;
 		get_packet_tuple(live_packet, &tuple);
-		endpoint->port = tuple.src.port;
+		endpoint->port = add_addr_script->data.add_addr.flag_E ?
+			tuple.dst.port : tuple.src.port;
 	}else if(add_addr_script->length == TCPOLEN_ADD_ADDR_V4_PORT ||
 		 add_addr_script->length == TCPOLEN_ADD_ADDR_V4_PORT_HMAC){
 		if(add_addr_script->data.add_addr.ipv4_w_port.port == UNDEFINED)


### PR DESCRIPTION
I have sent a patch:  "mptcp: send ADD_ADDR echo before create subflows" 
to send ADD_ADDR echo before creating subflows:
https://patchwork.kernel.org/project/mptcp/patch/1645779233-19742-1-git-send-email-liyonglong@chinatelecom.cn/

The patch cause some mptcp test case of packdrill failed: 
https://api.cirrus-ci.com/v1/artifact/task/6064998760841216/summary/summary.txt 

This series patch adaptive the patch I sent. 
Patch 1: fix packdrill can take case addr_echo before join new subflow.
Patch 2:  change some case to move  addr_echo rule ahead of mp_join_syn rule
