### PR TITLE
fix socket matching in case of outbound MP_JOIN

### DIFF
--- a/gtests/net/packetdrill/socket.h
+++ b/gtests/net/packetdrill/socket.h
@@ -47,6 +47,7 @@ enum socket_state_t {
 	SOCKET_ACTIVE_CONNECTING,	/* after connect() call */
 	SOCKET_ACTIVE_SYN_SENT,		/* after sending client's SYN */
 	SOCKET_ACTIVE_SYN_ACKED,	/* after client's SYN is ACKed */
+	SOCKET_ACTIVE_MP_JOIN_SYN_SENT, /* after sending client's MP_JOIN SYN */
 };
 
 /* A TCP/UDP/IP address for an endpoint. */


### PR DESCRIPTION
previously, we needed to extract addresses/ports for the next subflow
from ADD_ADDR packets. Instead, we can accept an arbitrary SYN packet
after parsing an outbound MP_JOIN packet: this allows scripts with
more than 1 subflows and no ADD_ADDR at all.

Signed-off-by: Davide Caratti <dcaratti@redhat.com>