### PR TITLE
more MP_PRIO coverage

### DIFF
--- a/gtests/net/mptcp/mp_prio/mp_prio_client_inbound.pkt
+++ b/gtests/net/mptcp/mp_prio/mp_prio_client_inbound.pkt
@@ -1,0 +1,50 @@
+--tolerance_usecs=400000
+`../common/defaults.sh`
+
++0    `../common/multi-ep.sh -e 1 -m subflow -b`
+
++0.0  socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0  fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
++0.0  fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+
++0.0  connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
++0.0    > addr[caddr0] > addr[saddr0]   S   0:0(0)                        <mss 1460, sackOK, TS val 4074410674 ecr 0,          nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++0.0    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.0    >                                .  1:1(0)      ack 1             <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey, skey]>
+
++0.2  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.0  fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
+
++1.0  write(3, ..., 2) = 2
++0.0    >                               P.  1:3(2)      ack 1              <nop, nop, TS val 4074418292 ecr 4074410674,                       mpcapable v1 flags[flag_h] key[ckey, skey] mpcdatalen 2, nop, nop>
++0.0    <                                .  1:1(0)      ack 3   win 65535  <nop, nop, TS val 4074418292 ecr 4074410674,       dss dack8=3 nocs>
+
++0.0    >  addr[caddr1] > addr[saddr0]  S   0:0(0)                         <mss 1460, sackOK, TS val 448955294 ecr 0,         nop, wscale 8, mp_join_syn backup=1  address_id=1 token=sha256_32(skey)>
++0.0    <                               S.  0:0(0)      ack 1   win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack backup=1 address_id=1 sender_hmac=auto>
++0.0    >                                .  1:1(0)      ack 1              <nop, nop,         TS val 448955294 ecr 448955294,                mp_join_ack sender_hmac=auto>
++0.0    <                                .  1:1(0)      ack 1   win 256    <nop, nop,         TS val 448955294 ecr 448955294, dss dack8=3 nocs>
+
+// packetdrill is sending 100B through a subflow marked as backup, but the kernel under test correctly delivers them to applications.
+// however, the kernel under test should keep sending data using the non-backup subflow
++1.0    <                                .  1:101(100)  ack 1   win 256                      <TS val 448955294 ecr 448955294, dss dack8=3   dsn8=1 ssn=1 dll=100 nocs>
++0.0    >                                .  1:1(0)      ack 101            <nop, nop,         TS val 448955294 ecr 448955294, dss dack8=101                      nocs>
++0.0  read (3, ..., 100) = 100
+
++0.0  write(3, ..., 20) = 20
++0.0    >  addr[caddr0] > addr[saddr0]  P.  3:23(20)    ack 1              <nop, nop,         TS val 448955294 ecr 448955294, dss dack8=101 dsn8=3 ssn=3 dll=20  nocs, nop, nop>
+
+// a flip of the "backup" bit on both subflows causes data (20B retrasmitted and 10B new) to be sent on the subflow having id = 1.
++0.0    <  addr[saddr0] > addr[caddr1]   .  101:101(0)  ack 1   win 256    <nop, nop,         TS val 448955294 ecr 448955294, mp_prio backup=0, nop>
+// a MPTCP retransmission is triggered by acking 20 bytes at TCP level with no DSS ACK
++0.0    <  addr[saddr0] > addr[caddr0]   .  1:1(0)      ack 23  win 256    <nop, nop,         TS val 448955294 ecr 448955294, mp_prio backup=1, nop>
++0.1    >  addr[caddr1] > addr[saddr0]  P.  1:21(20)    ack 101            <nop, nop,         TS val 448955294 ecr 448955294, dss dack8=101 dsn8=3 ssn=1 dll=20  nocs, nop, nop>
++0.0    <                                .  101:101(0)  ack 1   win 256    <nop, nop,         TS val 448955294 ecr 448955294, dss dack8=23 nocs>
+
++0.1  write(3, ..., 10) = 10
++0.0    >  addr[caddr1] > addr[saddr0]  P.  21:31(10)   ack 101            <nop, nop,         TS val 448955294 ecr 448955294, dss dack8=101 dsn8=23 ssn=21 dll=10 nocs, nop, nop>
++0.0    <                                .  101:101(0)  ack 11  win 256    <nop, nop,         TS val 448955294 ecr 448955294, dss dack8=33 nocs>
+
++0.1  close(3) = 0
++0.0    >  addr[caddr0] > addr[saddr0]   .  23:23(0)    ack 1              <nop, nop,         TS val 448955295 ecr 448955295, dss dack8=101 dsn8=33 ssn=0 dll=1 nocs fin, nop, nop>
++0.0    >  addr[caddr1] > addr[saddr0]   .  31:31(0)    ack 101            <nop, nop,         TS val 448955295 ecr 448955295, dss dack8=101 dsn8=33 ssn=0 dll=1 nocs fin, nop, nop>

--- a/gtests/net/mptcp/mp_prio/mp_prio_client_outbound.pkt
+++ b/gtests/net/mptcp/mp_prio/mp_prio_client_outbound.pkt
@@ -1,0 +1,39 @@
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
++0    `../common/multi-ep.sh -e 1 -m subflow -b`
+
++0.0  socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0  fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
++0.0  fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+
++0.0  connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
++0.0    > addr[caddr0] > addr[saddr0]   S   0:0(0)                        <mss 1460, sackOK, TS val 4074410674 ecr 0,          nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++0.0    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.0    >                                .  1:1(0)      ack 1             <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey, skey]>
+
++0.2  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.0  fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
+
++1.0  write(3, ..., 2) = 2
++0.0    >                               P.  1:3(2)      ack 1             <nop, nop, TS val 4074418292 ecr 4074410674,                        mpcapable v1 flags[flag_h] key[ckey, skey] mpcdatalen 2, nop, nop>
++0.0    <                                .  1:1(0)      ack 3  win 65535  <nop, nop, TS val 4074418292 ecr 4074410674,       dss dack8=3 nocs>
+
++0.0    >  addr[caddr1] > addr[saddr0]  S   0:0(0)                        <mss 1460, sackOK, TS val 448955294 ecr 0,         nop, wscale 8, mp_join_syn     backup=1 address_id=1 token=sha256_32(skey)>
++0.0    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack backup=1 address_id=1 sender_hmac=auto>
++0.0    >                                .  1:1(0)      ack 1             <nop, nop,         TS val 448955294 ecr 448955294,                mp_join_ack                           sender_hmac=auto>
++0.0    <                                .  1:1(0)      ack 1  win 256    <nop, nop,         TS val 448955294 ecr 448955294, dss dack8=3                      nocs>
+
++1.0    <                                .  1:101(100)  ack 1  win 256                      <TS val 448955294 ecr 448955294, dss dack8=3 dsn8=1 ssn=1 dll=100 nocs>
++0.0    >                                .  1:1(0)      ack 101           <nop, nop,         TS val 448955294 ecr 448955294, dss dack8=101                    nocs>
++0.0  read (3, ..., 100) = 100
+
++0.0    `ip mptcp endpoint change id 1 nobackup`
++0.0    >                                .  1:1(0)      ack 101           <nop, nop, TS val 448955294 ecr 448955294,         dss dack8=101 nocs, mp_prio backup=0, nop>
++0.0    `ip mptcp endpoint change id 1 backup`
++0.0    >                                .  1:1(0)      ack 101           <nop, nop, TS val 448955294 ecr 448955294,         dss dack8=101 nocs, mp_prio backup=1, nop>
+
++0.1  close(3) = 0
++0.0    >  addr[caddr0] > addr[saddr0]   .  3:3(0)      ack 1             <nop, nop, TS val 4074418292 ecr 4074418293,       dss dack8=101 dsn8=3 ssn=0 dll=1 nocs fin, nop, nop>
++0.0    >  addr[caddr1] > addr[saddr0]   .  1:1(0)      ack 101           <nop, nop, TS val 4074418292 ecr 4074418293,       dss dack8=101 dsn8=3 ssn=0 dll=1 nocs fin, nop, nop>


### PR DESCRIPTION
add 2 additional tests that cover MP_PRIO on clients:

1) check that MP_PRIO is sent after a change of the 'backup' flag of a
   subflow endpoint
2) check that subflows react consistently when inbound MP_PRIO changes
   the 'backup' flag on endpoints

Signed-off-by: Davide Caratti <dcaratti@redhat.com>