### PR TITLE
mptcp: Fix add_addr hmac computation and compiler warnings

### DIFF
--- a/gtests/net/packetdrill/mptcp.c
+++ b/gtests/net/packetdrill/mptcp.c
@@ -820,8 +820,8 @@ static int mp_join_syn_ack(struct packet *packet_to_modify,
 
 		//Build key for HMAC-SHA1
 		unsigned char hmac_key[16];
-		unsigned long *key_b = (unsigned long*)hmac_key;
-		unsigned long *key_a = (unsigned long*)&(hmac_key[8]);
+		u64 *key_b = (u64 *)hmac_key;
+		u64 *key_a = (u64 *)&(hmac_key[8]);
 		*key_b = mp_state.kernel_key;
 		*key_a = mp_state.packetdrill_key;
 
@@ -1904,8 +1904,8 @@ static u64 add_addr_ipv4_hmac(u64 key1, u64 key2, u8 address_id, struct in_addr*
 {
 	//Build key for HMAC-SHA256
 	unsigned char hmac_key[16];
-	unsigned long *key_a = (unsigned long*)hmac_key;
-	unsigned long *key_b = (unsigned long*)&(hmac_key[8]);
+	u64 *key_a = (u64 *)hmac_key;
+	u64 *key_b = (u64 *)&(hmac_key[8]);
 	*key_a = key1;
 	*key_b = key2;
 
@@ -1923,8 +1923,8 @@ static u64 add_addr_ipv6_hmac(u64 key1, u64 key2, u8 address_id, struct in6_addr
 {
 	//Build key for HMAC-SHA256
 	unsigned char hmac_key[16];
-	unsigned long *key_a = (unsigned long*)hmac_key;
-	unsigned long *key_b = (unsigned long*)&(hmac_key[8]);
+	u64 *key_a = (u64 *)hmac_key;
+	u64 *key_b = (u64 *)&(hmac_key[8]);
 	*key_a = key1;
 	*key_b = key2;
 

--- a/gtests/net/packetdrill/mptcp_utils.c
+++ b/gtests/net/packetdrill/mptcp_utils.c
@@ -225,7 +225,7 @@ u32 generate_32() {
 	return rand();
 }
 
-key64 get_barray_from_key64(unsigned long long key) {
+key64 get_barray_from_key64(u64 key) {
 	return *(key64 *) (unsigned char*) &key;
 }
 
@@ -587,8 +587,8 @@ void mptcp_hmac_sha256(u64 key_1, u64 key_2, u32 rand_1, u32 rand_2,
 {
 	/* Build key for HMAC-SHA256 */
 	unsigned char hmac_key[16];
-	unsigned long *key_a = (unsigned long*)hmac_key;
-	unsigned long *key_b = (unsigned long*)&(hmac_key[8]);
+	u64 *key_a = (u64 *)hmac_key;
+	u64 *key_b = (u64 *)&(hmac_key[8]);
 	*key_a = key_1;
 	*key_b = key_2;
 

--- a/gtests/net/packetdrill/run_system_call.c
+++ b/gtests/net/packetdrill/run_system_call.c
@@ -28,6 +28,7 @@
 #include <arpa/inet.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #include <limits.h>
 #include <linux/netlink.h>
 #include <netinet/in.h>
@@ -857,7 +858,7 @@ static bool cmsg_expect_eq(struct state *state, struct msghdr *expect,
 		}
 		if (acm->cmsg_len != ecm->cmsg_len) {
 			asprintf(error,
-				 "Bad len in cmsg %d: expected=%lu actual=%lu",
+				 "Bad len in cmsg %d: expected=%zu actual=%zu",
 				 i, ecm->cmsg_len, acm->cmsg_len);
 			return false;
 		}
@@ -2935,7 +2936,7 @@ static int get_epoll_event_from_expr(struct state *state,
 	if (epollev_expr->ptr) {
 		if (check_type(epollev_expr->ptr, EXPR_INTEGER, error))
 			return STATUS_ERR;
-		event->data.ptr = (void *)epollev_expr->ptr->value.num;
+		event->data.ptr = (void *)(uintptr_t)epollev_expr->ptr->value.num;
 		*epoll_data = EPOLL_DATA_PTR;
 	} else if (epollev_expr->fd) {
 		if (check_type(epollev_expr->fd, EXPR_INTEGER, error))
@@ -3141,8 +3142,8 @@ static int syscall_epoll_wait(struct state *state, struct syscall_spec *syscall,
 		if (event_script.data.u64 != event_live->data.u64) {
 			asprintf(error,
 				 "epoll_event->data does not match script: "
-				 "expected: %lu "
-				 "actual: %lu\n",
+				 "expected: %" PRIu64 " "
+				 "actual: %" PRIu64 "\n",
 				 event_script.data.u64,
 				 event_live->data.u64);
 			goto error_out;
@@ -3260,8 +3261,8 @@ static int syscall_splice(struct state *state, struct syscall_spec *syscall,
 				fd_out_live, (loff_t *) &off_out,
 				len, flags);
 	} else {
-		result = splice(fd_in_live, (loff_t *) off_in, fd_out_live,
-				(loff_t *) off_out, len, flags);
+		result = splice(fd_in_live, (loff_t *)(uintptr_t)off_in, fd_out_live,
+				(loff_t *)(uintptr_t)off_out, len, flags);
 	}
 	if (end_syscall(state, syscall, CHECK_EXACT, result, error))
 		return STATUS_ERR;


### PR DESCRIPTION
I see that the ADD_ADDR-hmac is incorrectly calculated. The reason is because the key_a/b is an unsigned long and not a u64. Thus, when doing *key_a = key1, key1 will be truncated to 32bit.

Also, address some compile-time issues on my Ubuntu platform that I use for testing.