### PR TITLE
mptcp: adaptations for 'propagate fastclose error' patches

### DIFF
--- a/gtests/net/mptcp/dss/dss_fin_retrans_close_wait.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_retrans_close_wait.pkt
@@ -29,5 +29,4 @@
 
 // ACK the data_fin
 +0       <   .  2:2(0)  ack 1  win 450    <dss dack4=2 nocs>
-+0       >  F.  1:1(0)  ack 2             <dss dack4=2 nocs>
-+0       <   .  2:2(0)  ack 2  win 450    <dss dack4=2 nocs>
++0       >  R.  1:1(0)  ack 2             <mp_fastclose, mp_reset 0>

--- a/gtests/net/mptcp/dss/dss_fin_retrans_established.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_retrans_established.pkt
@@ -24,5 +24,4 @@
 // ACK the data_fin
 +0       <   .  2:2(0)  ack 1  win 450    <dss dack4=2 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
 +0       >   .  1:1(0)  ack 1             <dss dack4=2 nocs>
-+0       >  F.  1:1(0)  ack 1             <dss dack4=2 nocs>
-+0       <  F.  2:2(0)  ack 2  win 450    <dss dack4=2 nocs>
++0       >  R.  1:1(0)  ack 1             <mp_fastclose, mp_reset 0>

--- a/gtests/net/mptcp/dss/dss_fin_server.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_server.pkt
@@ -22,5 +22,4 @@
 +0     close(4) = 0
 +0       >   .  1:1(0)  ack 2             <dss dack4=2 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
 +0       <   .  2:2(0)  ack 1  win 450    <dss dack4=2 nocs>
-+0       >  F.  1:1(0)  ack 2             <dss dack4=2 nocs>
-+0       <   .  2:2(0)  ack 2  win 450    <dss dack4=2 nocs>
++0       >  R.  1:1(0)  ack 2             <mp_fastclose, mp_reset 0>

--- a/gtests/net/mptcp/syscalls/connect_close_full.pkt
+++ b/gtests/net/mptcp/syscalls/connect_close_full.pkt
@@ -23,13 +23,6 @@
 
 +0.0      <   .  1:1(0)  ack 1  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 dsn4=1 ssn=0 dll=1 nocs fin, nop, nop>
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
-+0.0      >  F.  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
-+0.0      <   .  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
 
-// reply with a small delay to let the kernel switching to a time-wait socket.
-+0.2      <  F.  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
-
-// the final ack will be emitted by a time-wait socket, no dack/mptcp options
-
-+0.0      >   .  2:2(0)  ack 2             <nop, nop,         TS val 101 ecr 700>
-
+// FastClose is sent
++0.0      >  R.  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, mp_fastclose, mp_reset 0>


### PR DESCRIPTION
These modifications are needed for [Paolo series](https://patchwork.kernel.org/project/mptcp/list/?series=675566&archive=both&state=*):

  mptcp: propagate fastclose error
  mptcp: use fastclose on more edge scenarios

Now some MP_FASTCLOSE are sent instead of DATA_FIN.

Link: https://patchwork.kernel.org/project/mptcp/patch/904c47ce96fa8d6d4c961a2480bf3aea702c3a9c.1662713367.git.pabeni@redhat.com/
Link: https://patchwork.kernel.org/project/mptcp/patch/c6f847aa503eb0a35e262f6b631f1d344cf552b8.1662713367.git.pabeni@redhat.com/
Link: https://github.com/multipath-tcp/mptcp_net-next/issues/295