### PR TITLE
mptcp: add FastOpen sender tests

### DIFF
--- a/gtests/net/mptcp/fastopen/client-MSG_FASTOPEN-no-cookie.pkt.TODO
+++ b/gtests/net/mptcp/fastopen/client-MSG_FASTOPEN-no-cookie.pkt.TODO
@@ -1,0 +1,20 @@
+// Send data with MSG_FASTOPEN
+--tolerance_usecs=100000
+`../common/defaults.sh
+ sysctl -q net.ipv4.tcp_fastopen=0x5`
+
++0.1    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0    fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
++0.0    sendto(3, ..., 500, MSG_FASTOPEN, ..., ...) = 500
+
++0.01     >  S   0:500(500)                           <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++0.01     <  S.  0:0(0)          ack 501   win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.01     >   .  501:501(0)      ack 1                <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
+
+// check the rest is OK
++0.1    write(3, ..., 1000) = 1000
++0.01     >  P.  501:1501(1000)  ack 1                <nop, nop, TS val 100 ecr 700, mpcapable v1 flags[flag_h] key[ckey, skey] mpcdatalen 1000, nop, nop>
++0.01     <   .  1:1(0)          ack 1501  win 225                                  <dss dack8=1001 nocs>
+
++0.1    close(3) = 0
++0.01     >   .  1501:1501(0)    ack 1                <nop, nop, TS val 100 ecr 700, dss dack4=1 dsn8=1001 ssn=0 dll=1 nocs fin, nop, nop>

--- a/gtests/net/mptcp/fastopen/client-MSG_FASTOPEN.pkt.TODO
+++ b/gtests/net/mptcp/fastopen/client-MSG_FASTOPEN.pkt.TODO
@@ -1,0 +1,30 @@
+// Send data with MSG_FASTOPEN
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
+// A first connection to store the cookie
+ 0.0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0    fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
++0.0    sendto(3, ..., 500, MSG_FASTOPEN, ..., ...) = -1 EINPROGRESS (Operation now in progress)
+
++0.01     >  S   0:0(0)                               <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO,          nop, nop, mpcapable v1 flags[flag_h] nokey>
++0.01     <  S.  0:0(0)          ack 1     win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, FO abcd1234, nop, nop, mpcapable v1 flags[flag_h] key[skey=2]>
++0.01     >   .  1:1(0)          ack 1                <nop, nop,         TS val 100 ecr 700,                                       mpcapable v1 flags[flag_h] key[ckey, skey]>
+
++0.01   close(3) = 0
++0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=1 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
++0.0      <   .  1:1(0)  ack 1  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 dsn4=1 ssn=0 dll=1 nocs fin, nop, nop>
++0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
++0.0      >  R.  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, mp_fastclose, mp_reset 0>
+
+
+// Another Fastopen request, now SYN will have data
++0.1    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 5
++0.0    fcntl(5, F_SETFL, O_RDWR|O_NONBLOCK) = 0
++0.0    sendto(5, ..., 500, MSG_FASTOPEN, ..., ...) = 500
+
++0.01     >  S   0:500(500)                           <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO abcd1234, nop, nop, mpcapable v1 flags[flag_h] nokey>
++0.01     <  S.  0:0(0)          ack 501   win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8,                        mpcapable v1 flags[flag_h] key[skey=2]>
+
+// Not supported by Packetdrill yet: ckey is not the expected on
+// +0.01  >   .  501:501(0)      ack 1                <nop, nop,         TS val 100 ecr 700,                                       mpcapable v1 flags[flag_h] key[ckey, skey]>

--- a/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_CONNECT-no-cookie.pkt
+++ b/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_CONNECT-no-cookie.pkt
@@ -1,0 +1,22 @@
+// Send data with MSG_FASTOPEN
+--tolerance_usecs=100000
+`../common/defaults.sh
+ sysctl -q net.ipv4.tcp_fastopen=0x5`
+
+ 0.0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0    fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
++0.0    setsockopt(3, SOL_TCP, TCP_FASTOPEN_CONNECT, [1], 4) = 0
++0.0    connect(3, ..., ...) = 0
++0.0    write(3, ..., 500) = 500
+
++0.01     >  S   0:500(500)                           <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++0.01     <  S.  0:0(0)          ack 501   win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.01     >   .  501:501(0)      ack 1                <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
+
+// check the rest is OK
++0.1    write(3, ..., 1000) = 1000
++0.01     >  P.  501:1501(1000)  ack 1                <nop, nop, TS val 100 ecr 700, mpcapable v1 flags[flag_h] key[ckey, skey] mpcdatalen 1000, nop, nop>
++0.01     <   .  1:1(0)          ack 1501  win 225                                  <dss dack8=1001 nocs>
+
++0.1    close(3) = 0
++0.01     >   .  1501:1501(0)    ack 1                <nop, nop, TS val 100 ecr 700, dss dack4=1 dsn8=1001 ssn=0 dll=1 nocs fin, nop, nop>

--- a/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_CONNECT.pkt
+++ b/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_CONNECT.pkt
@@ -1,0 +1,33 @@
+// Send data with MSG_FASTOPEN
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
+// A first connection to store the cookie
+ 0.0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0    fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
++0.0    setsockopt(3, SOL_TCP, TCP_FASTOPEN_CONNECT, [1], 4) = 0
++0.0    connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
+
++0.01     >  S   0:0(0)                               <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO,          nop, nop, mpcapable v1 flags[flag_h] nokey>
++0.01     <  S.  0:0(0)          ack 1     win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, FO abcd1234, nop, nop, mpcapable v1 flags[flag_h] key[skey=2]>
++0.01     >   .  1:1(0)          ack 1                <nop, nop,         TS val 100 ecr 700,                                       mpcapable v1 flags[flag_h] key[ckey, skey]>
+
++0.01   close(3) = 0
++0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=1 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
++0.0      <   .  1:1(0)  ack 1  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 dsn4=1 ssn=0 dll=1 nocs fin, nop, nop>
++0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
++0.0      >  R.  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, mp_fastclose, mp_reset 0>
+
+
+// Another Fastopen request, now SYN will have data
++0.1    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 5
++0.0    fcntl(5, F_SETFL, O_RDWR|O_NONBLOCK) = 0
++0.0    setsockopt(5, SOL_TCP, TCP_FASTOPEN_CONNECT, [1], 4) = 0
++0.0    connect(5, ..., ...) = 0
++0.0    write(5, ..., 500) = 500
+
++0.01     >  S   0:500(500)                           <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO abcd1234, nop, nop, mpcapable v1 flags[flag_h] nokey>
++0.01     <  S.  0:0(0)          ack 501   win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8,                        mpcapable v1 flags[flag_h] key[skey=2]>
+
+// Not supported by Packetdrill yet: ckey is not the expected on
+// +0.01  >   .  501:501(0)      ack 1                <nop, nop,         TS val 100 ecr 700,                                       mpcapable v1 flags[flag_h] key[ckey, skey]>

--- a/gtests/net/mptcp/fastopen/fastopen-invalid-buf-ptr.pkt
+++ b/gtests/net/mptcp/fastopen/fastopen-invalid-buf-ptr.pkt
@@ -1,0 +1,43 @@
+// Test TCP fastopen behavior with NULL as buffer pointer, but a non-zero
+// buffer length.
+// Similar to tcp/syscall_bad_arg/fastopen-invalid-buf-ptr.pkt but for MPTCP
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
+// Cache warmup: send a Fast Open cookie request
+ 0.0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0    fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
++0.0    setsockopt(3, SOL_TCP, TCP_FASTOPEN_CONNECT, [1], 4) = 0
++0.0    connect(3, ..., ...) = -1 EINPROGRESS (Operation is now in progress)
+
++0.01     >  S   0:0(0)                               <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO,          nop, nop, mpcapable v1 flags[flag_h] nokey>
++0.01     <  S.  0:0(0)          ack 1     win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, FO abcd1234, nop, nop, mpcapable v1 flags[flag_h] key[skey=2]>
++0.01     >   .  1:1(0)          ack 1                <nop, nop,         TS val 100 ecr 700,                                       mpcapable v1 flags[flag_h] key[ckey, skey]>
+
++0.01   close(3) = 0
++0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=1 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
++0.0      <   .  1:1(0)  ack 1  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 dsn4=1 ssn=0 dll=1 nocs fin, nop, nop>
++0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
++0.0      >  R.  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, mp_fastclose, mp_reset 0>
+
+// Test with MSG_FASTOPEN without TCP_FASTOPEN_CONNECT.
++0.0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 4
++0.0    fcntl(4, F_SETFL, O_RDWR|O_NONBLOCK) = 0
++0.0    sendto(4, NULL, 1, MSG_FASTOPEN, ..., ...) = -1
++0.0    close(4) = 0
+
+// Test with TCP_FASTOPEN_CONNECT without MSG_FASTOPEN.
++0.0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 5
++0.0    fcntl(5, F_SETFL, O_RDWR|O_NONBLOCK) = 0
++0.0    setsockopt(5, SOL_TCP, TCP_FASTOPEN_CONNECT, [1], 4) = 0
++0.0    connect(5, ..., ...) = 0
++0.0    sendto(5, NULL, 1, 0, ..., ...) = -1
++0.0    close(5) = 0
+
+// Test with both TCP_FASTOPEN_CONNECT and MSG_FASTOPEN.
++0.0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 6
++0.0    fcntl(6, F_SETFL, O_RDWR|O_NONBLOCK) = 0
++0.0    setsockopt(6, SOL_TCP, TCP_FASTOPEN_CONNECT, [1], 4) = 0
++0.0    connect(6, ..., ...) = 0
++0.0    sendto(6, NULL, 1, MSG_FASTOPEN, ..., ...) = -1
++0.0    close(6) = 0


### PR DESCRIPTION
For the moment, only the client part is validated.

2 methods are currently tested:
- `TCP_FASTOPEN_CONNECT`
- `MSG_FASTOPEN`

For each method, there are two tests:
- one without using TFO cookies
- one where a first connection is created to validate the cookie part. Then a second connection is established with data in the SYN.

Note that it looks like Packetdrill doesn't support creating a 2nd connection on the same script yet. When we do that, Packetdrill reports the 3rd ACK of the 2nd connection doesn't contain the expected the client key. But that's alright for the moment, tests have been split: with and without cookies.

These tests can be used to validate Benjamin' series: [`mptcp: add support for TFO, sender side only`](https://lore.kernel.org/mptcp/20220922135627.2019807-1-benjamin.hesmans@tessares.net/T/). In the v2, `MSG_FASTOPEN` support has been removed as it is part of Dmytro's series.