### PR TITLE
mptcp: update fastclose tests

### DIFF
--- a/gtests/net/mptcp/dss/dss_fin_retrans_close_wait.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_retrans_close_wait.pkt
@@ -29,4 +29,5 @@
 
 // ACK the data_fin
 +0       <   .  2:2(0)  ack 1  win 450    <dss dack4=2 nocs>
-+0       >  R.  1:1(0)  ack 2             <mp_fastclose, mp_reset 0>
++0       >  F.  1:1(0)  ack 2             <dss dack4=2 nocs>
++0       <   .  2:2(0)  ack 2  win 450    <dss dack4=2 nocs>

--- a/gtests/net/mptcp/dss/dss_fin_retrans_established.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_retrans_established.pkt
@@ -24,4 +24,5 @@
 // ACK the data_fin
 +0       <   .  2:2(0)  ack 1  win 450    <dss dack4=2 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
 +0       >   .  1:1(0)  ack 1             <dss dack4=2 nocs>
-+0       >  R.  1:1(0)  ack 1             <mp_fastclose, mp_reset 0>
++0       >  F.  1:1(0)  ack 1             <dss dack4=2 nocs>
++0       <  F.  2:2(0)  ack 2  win 450    <dss dack4=2 nocs>

--- a/gtests/net/mptcp/dss/dss_fin_server.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_server.pkt
@@ -22,4 +22,5 @@
 +0     close(4) = 0
 +0       >   .  1:1(0)  ack 2             <dss dack4=2 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
 +0       <   .  2:2(0)  ack 1  win 450    <dss dack4=2 nocs>
-+0       >  R.  1:1(0)  ack 2             <mp_fastclose, mp_reset 0>
++0       >  F.  1:1(0)  ack 2             <dss dack4=2 nocs>
++0       <   .  2:2(0)  ack 2  win 450    <dss dack4=2 nocs>

--- a/gtests/net/mptcp/fastopen/client-MSG_FASTOPEN.pkt.TODO
+++ b/gtests/net/mptcp/fastopen/client-MSG_FASTOPEN.pkt.TODO
@@ -15,7 +15,10 @@
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=1 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
 +0.0      <   .  1:1(0)  ack 1  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 dsn4=1 ssn=0 dll=1 nocs fin, nop, nop>
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
-+0.0      >  R.  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, mp_fastclose, mp_reset 0>
++0.0      >  F.  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
++0.0      <   .  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
++0.0      <  F.  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
++0.0      >   .  2:2(0)  ack 2             <nop, nop,         TS val 101 ecr 700>
 
 
 // Another Fastopen request, now SYN will have data

--- a/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_CONNECT.pkt
+++ b/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_CONNECT.pkt
@@ -16,7 +16,10 @@
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=1 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
 +0.0      <   .  1:1(0)  ack 1  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 dsn4=1 ssn=0 dll=1 nocs fin, nop, nop>
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
-+0.0      >  R.  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, mp_fastclose, mp_reset 0>
++0.0      >  F.  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
++0.0      <   .  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
++0.0      <  F.  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
++0.0      >   .  2:2(0)  ack 2             <nop, nop,         TS val 101 ecr 700>
 
 
 // Another Fastopen request, now SYN will have data

--- a/gtests/net/mptcp/fastopen/fastopen-invalid-buf-ptr.pkt
+++ b/gtests/net/mptcp/fastopen/fastopen-invalid-buf-ptr.pkt
@@ -18,7 +18,10 @@
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=1 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
 +0.0      <   .  1:1(0)  ack 1  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 dsn4=1 ssn=0 dll=1 nocs fin, nop, nop>
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
-+0.0      >  R.  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, mp_fastclose, mp_reset 0>
++0.0      >  F.  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
++0.0      <   .  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
++0.0      <  F.  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
++0.0      >   .  2:2(0)  ack 2             <nop, nop,         TS val 101 ecr 700>
 
 // Test with MSG_FASTOPEN without TCP_FASTOPEN_CONNECT.
 +0.0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 4

--- a/gtests/net/mptcp/syscalls/connect_close_full.pkt
+++ b/gtests/net/mptcp/syscalls/connect_close_full.pkt
@@ -23,6 +23,11 @@
 
 +0.0      <   .  1:1(0)  ack 1  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 dsn4=1 ssn=0 dll=1 nocs fin, nop, nop>
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
++0.0      >  F.  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
++0.0      <   .  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
 
-// FastClose is sent
-+0.0      >  R.  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, mp_fastclose, mp_reset 0>
+// reply with a small delay to let the kernel switching to a time-wait socket.
++0.2      <  F.  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
+
+// the final ack will be emitted by a time-wait socket, no dack/mptcp options
++0.0      >   .  2:2(0)  ack 2             <nop, nop,         TS val 101 ecr 700>


### PR DESCRIPTION
This sync again WRT kernel fastclose behavior, reverting commit 70ebe1514e3f ("mptcp: adaptations for 'propagate fastclose error' patches") and additionally handling the fastopen drills.

Signed-off-by: Paolo Abeni <pabeni@redhat.com>