### PR TITLE
mptcp: validate `TCP_FASTOPEN_NO_COOKIE`

### DIFF
--- a/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_CONNECT-no-cookie.pkt
+++ b/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_CONNECT-no-cookie.pkt
@@ -5,7 +5,9 @@
 
  0.0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
 +0.0    fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
++0.0    getsockopt(3, SOL_TCP, TCP_FASTOPEN_CONNECT, [0], [4]) = 0
 +0.0    setsockopt(3, SOL_TCP, TCP_FASTOPEN_CONNECT, [1], 4) = 0
++0.0    getsockopt(3, SOL_TCP, TCP_FASTOPEN_CONNECT, [1], [4]) = 0
 +0.0    connect(3, ..., ...) = 0
 +0.0    write(3, ..., 500) = 500
 
@@ -17,6 +19,10 @@
 +0.1    write(3, ..., 1000) = 1000
 +0.01     >  P.  501:1501(1000)  ack 1                <nop, nop, TS val 100 ecr 700, mpcapable v1 flags[flag_h] key[ckey, skey] mpcdatalen 1000, nop, nop>
 +0.01     <   .  1:1(0)          ack 1501  win 225                                  <dss dack8=1001 nocs>
+
+// Similar to TCP?
++0.0    setsockopt(3, SOL_TCP, TCP_FASTOPEN_CONNECT, [1], 4) = -1 (Invalid argument)
++0.0    getsockopt(3, SOL_TCP, TCP_FASTOPEN_CONNECT, [1], [4]) = 0
 
 +0.1    close(3) = 0
 +0.01     >   .  1501:1501(0)    ack 1                <nop, nop, TS val 100 ecr 700, dss dack4=1 dsn8=1001 ssn=0 dll=1 nocs fin, nop, nop>

--- a/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_NO_COOKIE.pkt
+++ b/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_NO_COOKIE.pkt
@@ -1,0 +1,30 @@
+// Send data with MSG_FASTOPEN
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
+// By default, cookies are needed
+
+ 0.0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0    fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
++0.0    setsockopt(3, SOL_TCP, TCP_FASTOPEN_CONNECT, [1], 4) = 0
++0.0    getsockopt(3, SOL_TCP, TCP_FASTOPEN_NO_COOKIE, [0], [4]) = 0
++0.0    setsockopt(3, SOL_TCP, TCP_FASTOPEN_NO_COOKIE, [1], 4) = 0
++0.0    getsockopt(3, SOL_TCP, TCP_FASTOPEN_NO_COOKIE, [1], [4]) = 0
++0.0    connect(3, ..., ...) = 0
++0.0    write(3, ..., 500) = 500
+
++0.01     >  S   0:500(500)                           <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++0.01     <  S.  0:0(0)          ack 501   win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.01     >   .  501:501(0)      ack 1                <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
+
+// check the rest is OK
++0.1    write(3, ..., 1000) = 1000
++0.01     >  P.  501:1501(1000)  ack 1                <nop, nop, TS val 100 ecr 700, mpcapable v1 flags[flag_h] key[ckey, skey] mpcdatalen 1000, nop, nop>
++0.01     <   .  1:1(0)          ack 1501  win 225                                  <dss dack8=1001 nocs>
+
+// Check we properly handle this like TCP
++0.0    setsockopt(3, SOL_TCP, TCP_FASTOPEN_NO_COOKIE, [1], 4) = -1 (Invalid argument)
++0.0    getsockopt(3, SOL_TCP, TCP_FASTOPEN_NO_COOKIE, [1], [4]) = 0
+
++0.1    close(3) = 0
++0.01     >   .  1501:1501(0)    ack 1                <nop, nop, TS val 100 ecr 700, dss dack4=1 dsn8=1001 ssn=0 dll=1 nocs fin, nop, nop>

--- a/gtests/net/packetdrill/symbols_linux.c
+++ b/gtests/net/packetdrill/symbols_linux.c
@@ -187,6 +187,8 @@ struct int_symbol platform_symbols_table[] = {
 	{ TCP_USER_TIMEOUT,                 "TCP_USER_TIMEOUT"                },
 	{ TCP_FASTOPEN,                     "TCP_FASTOPEN"                    },
 	{ TCP_FASTOPEN_CONNECT,             "TCP_FASTOPEN_CONNECT"            },
+	{ TCP_FASTOPEN_KEY,                 "TCP_FASTOPEN_KEY"                },
+	{ TCP_FASTOPEN_NO_COOKIE,           "TCP_FASTOPEN_NO_COOKIE"          },
 	{ TCP_TIMESTAMP,                    "TCP_TIMESTAMP"                   },
 	{ TCP_NOTSENT_LOWAT,                "TCP_NOTSENT_LOWAT"               },
 	{ TCP_INQ,			    "TCP_INQ"			      },

--- a/gtests/net/packetdrill/tcp.h
+++ b/gtests/net/packetdrill/tcp.h
@@ -61,6 +61,8 @@
 #define TCP_SAVED_SYN            28  /* Get SYN headers recorded for connection */
 #define TCP_REPAIR_WINDOW        29  /* Get/set window parameters */
 #define TCP_FASTOPEN_CONNECT     30  /* Attempt FastOpen with connect */
+#define TCP_FASTOPEN_KEY         33  /* Set the key for Fast Open (cookie) */
+#define TCP_FASTOPEN_NO_COOKIE   34  /* Enable TFO without a TFO cookie */
 
 #ifndef TCP_INQ
 #define TCP_INQ			 36


### PR DESCRIPTION
(This is on top of #90, please ignore '`mptcp: fastopen: check getsockopt()` commit)

I'm planning to upstream the first commit, this is not specific to MPTCP.

The last one is the interesting one to validate `TCP_FASTOPEN_NO_COOKIE`. The kernel patches are going to be sent soon.