### PR TITLE
mptcp: add delays before time-wait switch

### DIFF
--- a/gtests/net/mptcp/fastopen/client-MSG_FASTOPEN.pkt.TODO
+++ b/gtests/net/mptcp/fastopen/client-MSG_FASTOPEN.pkt.TODO
@@ -17,7 +17,9 @@
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
 +0.0      >  F.  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
 +0.0      <   .  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
-+0.0      <  F.  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
+
+// reply with a small delay to let the kernel switching to a time-wait socket.
++0.2      <  F.  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
 +0.0      >   .  2:2(0)  ack 2             <nop, nop,         TS val 101 ecr 700>
 
 

--- a/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_CONNECT.pkt
+++ b/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_CONNECT.pkt
@@ -18,7 +18,9 @@
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
 +0.0      >  F.  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
 +0.0      <   .  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
-+0.0      <  F.  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
+
+// reply with a small delay to let the kernel switching to a time-wait socket.
++0.2      <  F.  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
 +0.0      >   .  2:2(0)  ack 2             <nop, nop,         TS val 101 ecr 700>
 
 

--- a/gtests/net/mptcp/fastopen/fastopen-invalid-buf-ptr.pkt
+++ b/gtests/net/mptcp/fastopen/fastopen-invalid-buf-ptr.pkt
@@ -20,7 +20,9 @@
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
 +0.0      >  F.  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
 +0.0      <   .  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
-+0.0      <  F.  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
+
+// reply with a small delay to let the kernel switching to a time-wait socket.
++0.2      <  F.  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
 +0.0      >   .  2:2(0)  ack 2             <nop, nop,         TS val 101 ecr 700>
 
 // Test with MSG_FASTOPEN without TCP_FASTOPEN_CONNECT.


### PR DESCRIPTION
Our internal CI at Tessares reported an issue with some fastopen tests where we expect to see the very end of a connection.

The error only happens with a debug kernel config and on a slow/old machine. I didn't manage to reproduce this on my side even if it is easy to reproduce the problem on this specific CI machine.

Here is an example of error we can see:

    client-TCP_FASTOPEN_CONNECT.pkt:22: error handling packet: live packet field ipv4_total_length: expected: 52 (0x34) vs actual: 60 (0x3c)
    script packet:  0.024743 . 2:2(0) ack 2 <nop,nop,TS val 101 ecr 700>
    actual packet:  0.024933 . 2:2(0) ack 2 win 256 <nop,nop,TS val 124 ecr 700,dss dack4 3007449510 flags: A>

In other words, the last ACK after the FINs exchange has MPTCP options.

The fix is similar to commit 2aa2bda ("mptcp: update fastclose tests") where Paolo modified `syscalls/connect_close_full.pkt` test to add some delays before injecting the last FIN+ACK. This makes sure the socket has switched to TIME_WAIT state where no MPTCP options are added.