### PR TITLE
mptcp: validate TFO_CONNECT with blocking sendmsg

### DIFF
--- a/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_CONNECT-blocking-sendmsg.pkt
+++ b/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_CONNECT-blocking-sendmsg.pkt
@@ -1,0 +1,17 @@
+// Send data in SYN with a blocking sendto()
+--tolerance_usecs=100000
+`../common/defaults.sh
+ sysctl -q net.ipv4.tcp_fastopen=0x5`
+
+ 0.0      socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0      fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
++0.0      setsockopt(3, SOL_TCP, TCP_FASTOPEN_CONNECT, [1], 4) = 0
++0.0      connect(3, ..., ...) = 0
+
+// Switch to "blocking" mode, only the msk should be "blocked"
++0.0      fcntl(3, F_SETFL, O_RDWR) = 0
++0...0.4  sendto(3, ..., 500, 0, ..., ...) = 500
+
++0.0        >  S   0:500(500)                           <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++0.4        <  S.  0:0(0)          ack 501   win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.0        >   .  501:501(0)      ack 1                <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>


### PR DESCRIPTION
Our CI found a deadlock when validating MSG_FASTOPEN, see:

  https://cirrus-ci.com/task/6007236538400768

Paolo noticed it can also happen with TCP_CONNECT_FASTOPEN.

Here is a new test to reproduce the deadlock. The calltrace is visible when the test is stopped (timeout or CTRL+C).

Co-developed-by: Paolo Abeni
Signed-off-by: Paolo Abeni
Signed-off-by: Matthieu Baerts