### PR TITLE
mptcp: fastopen: client-MSG_FASTOPEN.pkt

### DIFF
--- a/gtests/net/mptcp/fastopen/client-MSG_FASTOPEN.pkt
+++ b/gtests/net/mptcp/fastopen/client-MSG_FASTOPEN.pkt
@@ -1,5 +1,5 @@
 // Send data with MSG_FASTOPEN
---tolerance_usecs=100000
+--tolerance_usecs=400000
 `../common/defaults.sh`
 
 // A first connection to store the cookie
@@ -8,19 +8,21 @@
 +0.0    sendto(3, ..., 500, MSG_FASTOPEN, ..., ...) = -1 EINPROGRESS (Operation now in progress)
 
 +0.01     >  S   0:0(0)                               <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO,          nop, nop, mpcapable v1 flags[flag_h] nokey>
-+0.01     <  S.  0:0(0)          ack 1     win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, FO abcd1234, nop, nop, mpcapable v1 flags[flag_h] key[skey=2]>
-+0.01     >   .  1:1(0)          ack 1                <nop, nop,         TS val 100 ecr 700,                                       mpcapable v1 flags[flag_h] key[ckey, skey]>
++0.01     <  S.  0:0(0)          ack 1     win 65535  <mss 1460, nop, nop, sackOK, nop, wscale 8, FO abcd1234, nop, nop, mpcapable v1 flags[flag_h] key[skey=2]>
++0.01     >   .  1:1(0)          ack 1     win 256    <mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 +0.01   close(3) = 0
-+0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=1 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
-+0.0      <   .  1:1(0)  ack 1  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 dsn4=1 ssn=0 dll=1 nocs fin, nop, nop>
-+0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
-+0.0      >  F.  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
++0.0      >   .  1:1(0)  ack 1  win 256    <dss dack4=1 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
++0.0      <   .  1:1(0)  ack 1  win 256    <dss dack4=2 dsn4=1 ssn=0 dll=1 nocs fin, nop, nop>
++0.0      >   .  1:1(0)  ack 1  win 256    <dss dack4=2 nocs>
++0.0      >  F.  1:1(0)  ack 1  win 256    <dss dack4=2 nocs>
 +0.0      <   .  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
 
 // reply with a small delay to let the kernel switching to a time-wait socket.
 +0.4      <  F.  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
-+0.0      >   .  2:2(0)  ack 2             <nop, nop,         TS val 101 ecr 700>
++0.0      >   .  2:2(0)  ack 2  win 256    
+
+      
 
 
 // Another Fastopen request, now SYN will have data


### PR DESCRIPTION
This commit adds feature to test client-MSG_FASTOPEN.

Tested on  by doing the following:
root@(none):/opt/packetdrill/gtests/net# ./packetdrill/run_all.py -S -v -L -l ./mptcp/fastopen/client-MSG_FASTOPEN.pkt
OK   [/opt/packetdrill/gtests/net/mptcp/fastopen/client-MSG_FASTOPEN.pkt (ipv4)]
stdout:
stderr:
OK   [/opt/packetdrill/gtests/net/mptcp/fastopen/client-MSG_FASTOPEN.pkt (ipv6)]
stdout:
stderr:
OK   [/opt/packetdrill/gtests/net/mptcp/fastopen/client-MSG_FASTOPEN.pkt (ipv4-mapped-v6)]
stdout:
stderr:
Ran    3 tests:    3 passing,    0 failing,    0 timed out (7.24 sec): ./mptcp/fastopen/client-MSG_FASTOPEN.pkt

Signed-off-by: Dmytro Shytyi <github.dmytro@shytyi.net>