### PR TITLE
mptcp: increase tolerance for ADD_ADDR echo

### DIFF
--- a/gtests/net/mptcp/add_addr/add_addr4_client.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr4_client.pkt
@@ -1,5 +1,5 @@
 // connection initiated by the kernel
---tolerance_usecs=200000
+--tolerance_usecs=250000
 `../common/defaults.sh`
 
 +0     `../common/client.sh`

--- a/gtests/net/mptcp/add_addr/add_addr4_port_client.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr4_port_client.pkt
@@ -1,5 +1,5 @@
 // connection initiated by the kernel
---tolerance_usecs=200000
+--tolerance_usecs=250000
 `../common/defaults.sh`
 
 +0     `../common/client.sh`

--- a/gtests/net/mptcp/add_addr/add_addr6_client.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr6_client.pkt
@@ -1,5 +1,5 @@
 // connection initiated by the kernel
---tolerance_usecs=200000
+--tolerance_usecs=250000
 `../common/defaults.sh`
 
 +0     `../common/client.sh`

--- a/gtests/net/mptcp/add_addr/add_addr6_port_client.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr6_port_client.pkt
@@ -1,5 +1,5 @@
 // connection initiated by the kernel
---tolerance_usecs=200000
+--tolerance_usecs=250000
 `../common/defaults.sh`
 
 +0     `../common/client.sh`


### PR DESCRIPTION
ADD_ADDR tests are still failing from time to time, e.g.

  https://api.cirrus-ci.com/v1/artifact/task/5865364507590656/summary/summary.txt

Extract:

    # add_addr4_client.pkt:30: error handling packet: timing error: expected outbound packet at 29.353157 sec but happened at 31.637496 sec; tolerance 2.041380 sec
    # add_addr4_port_client.pkt:22: error handling packet: timing error: expected outbound packet at 26.566128 sec but happened at 28.835277 sec; tolerance 2.004506 sec

I suspect that it is due to 2 things:

- Sending the ADD_ADDR echo is a slower process
- The ADD_ADDR tests are the first Packetdrill tests started by the CI

Increasing the tolerance should avoid false positives while keeping these tests useful.