### PR TITLE
mptcp: add_addr: more tolerance for retry tests

### DIFF
--- a/gtests/net/mptcp/add_addr/add_addr_retry_plain.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr_retry_plain.pkt
@@ -1,5 +1,5 @@
 // connection initiated by packetdrill
---tolerance_usecs=200000
+--tolerance_usecs=250000
 `../common/defaults.sh`
 
 +0     `sysctl -wq net.mptcp.add_addr_timeout=1`


### PR DESCRIPTION
Similar to commit fab205f ("mptcp: increase tolerance for ADD_ADDR echo"), it seems needed to add a bit more tolerance for this test with ADD_ADDR echo to avoid false positives reported by the CI, e.g.

  https://api.cirrus-ci.com/v1/artifact/task/6122416422780928/summary/summary.txt

We can see:

    add_addr_retry_plain.pkt:22: error handling packet: timing error: expected outbound packet at 3.413407 sec but happened at 2.511442 sec; tolerance 0.800000 sec
    add_addr_retry_plain.pkt:22: error handling packet: timing error: expected outbound packet at 3.412489 sec but happened at 2.569763 sec; tolerance 0.800000 sec