### PR TITLE
mptcp: tfo: server: validate TCP_FASTOPEN_NO_COOKIE sockopt

### DIFF
--- a/gtests/net/mptcp/fastopen/server-TCP_FASTOPEN_NO_COOKIE.pkt
+++ b/gtests/net/mptcp/fastopen/server-TCP_FASTOPEN_NO_COOKIE.pkt
@@ -1,0 +1,28 @@
+// Receive data with TFO + cookie
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
+ 0.0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0    setsockopt(3, SOL_TCP, TCP_FASTOPEN, [2], 4) = 0
++0.0    getsockopt(3, SOL_TCP, TCP_FASTOPEN_NO_COOKIE, [0], [4]) = 0
++0.0    setsockopt(3, SOL_TCP, TCP_FASTOPEN_NO_COOKIE, [1], 4) = 0
++0.0    getsockopt(3, SOL_TCP, TCP_FASTOPEN_NO_COOKIE, [1], [4]) = 0
+
++0.0    bind(3, ..., ...) = 0
++0.0    listen(3, 1) = 0
+
++0.0      <  S   0:500(500)               win 65535  <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO, nop, nop, mpcapable v1 flags[flag_h] nokey>
++0.01     >  S.  0:0(0)          ack 501             <mss 1460, sackOK, TS val 100 ecr 100, nop, wscale 8,               mpcapable v1 flags[flag_h] key[skey]>
++0.01     <   .  501:501(0)      ack 1    win 450    <nop, nop,         TS val 100 ecr 100,                              mpcapable v1 flags[flag_h] key[ckey=2, skey]>
+
++0.01   accept(3, ..., ...) = 4
+
+// check the rest is OK
++0.01     <  P.  501:1501(1000)  ack 1     win 225   <nop, nop, TS val 100 ecr 100, mpcapable v1 flags[flag_h] key[ckey, skey] mpcdatalen 1000, nop, nop>
++0.01     >   .  1:1(0)          ack 1501            <nop, nop, TS val 100 ecr 100, dss dack8=1001 nocs>
+
++0.2    read(4, ..., 1500) = 1500
+
++0.2    close(4) = 0
++0.01     >   .  1:1(0)          ack 1501            <nop, nop, TS val 100 ecr 700, dss dack8=1001 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>

--- a/gtests/net/tcp/fastopen/mptcp-like/server-TCP_FASTOPEN_NO_COOKIE.pkt
+++ b/gtests/net/tcp/fastopen/mptcp-like/server-TCP_FASTOPEN_NO_COOKIE.pkt
@@ -1,0 +1,29 @@
+// Receive data with TFO + cookie
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
+ 0.0    socket(..., SOCK_STREAM, IPPROTO_TCP) = 3
++0.0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0    setsockopt(3, SOL_TCP, TCP_FASTOPEN, [2], 4) = 0
+// note: we cannot set 0x202 above to have the no cookie mode, we need to use TCP_FASTOPEN_NO_COOKIE
++0.0    getsockopt(3, SOL_TCP, TCP_FASTOPEN_NO_COOKIE, [0], [4]) = 0
++0.0    setsockopt(3, SOL_TCP, TCP_FASTOPEN_NO_COOKIE, [1], 4) = 0
++0.0    getsockopt(3, SOL_TCP, TCP_FASTOPEN_NO_COOKIE, [1], [4]) = 0
+
++0.0    bind(3, ..., ...) = 0
++0.0    listen(3, 1) = 0
+
++0.0      <  S   0:500(500)               win 65535  <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO, nop, nop>
++0.01     >  S.  0:0(0)          ack 501             <mss 1460, sackOK, TS val 100 ecr 100, nop, wscale 8>
++0.01     <   .  501:501(0)      ack 1    win 450    <nop, nop,         TS val 100 ecr 100>
+
++0.01   accept(3, ..., ...) = 4
+
+// check the rest is OK
++0.01     <  P.  501:1501(1000)  ack 1     win 225   <nop, nop, TS val 100 ecr 100>
++0.01     >   .  1:1(0)          ack 1501            <nop, nop, TS val 100 ecr 100>
+
++0.01   read(4, ..., 1500) = 1500
+
++0.1    close(4) = 0
++0.01     >  F.  1:1(0)          ack 1501            <nop, nop, TS val 100 ecr 700>


### PR DESCRIPTION
This validates TCP_FASTOPEN_NO_COOKIE socket option support for the server side.

An equivalent test for (plain) TCP is also available.