### PR TITLE
Revert "Revert "mptcp: tfo: add basic server side coverage""

### DIFF
--- a/gtests/net/mptcp/fastopen/server-TCP_FASTOPEN-cookie-data.pkt
+++ b/gtests/net/mptcp/fastopen/server-TCP_FASTOPEN-cookie-data.pkt
@@ -1,0 +1,29 @@
+// Receive data with TFO + cookie: data
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
+// A first connection to store the cookie
+ 0.0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0    setsockopt(3, SOL_TCP, TCP_FASTOPEN, [2], 4) = 0
+
++0.0    bind(3, ..., ...) = 0
++0.0    listen(3, 1) = 0
+
+// The Cookie has already been exchanged before, data can already been exchanged
++0.01     <  S   0:500(500)                win 65535  <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO TFO_COOKIE, nop, nop, mpcapable v1 flags[flag_h] nokey>
++0.01     >  S.  0:0(0)          ack 501              <mss 1460, sackOK, TS val 100 ecr 100, nop, wscale 8,                          mpcapable v1 flags[flag_h] key[skey]>
++0.01     <   .  501:501(0)      ack 1     win 450    <                                                                              mpcapable v1 flags[flag_h] key[ckey, skey]>
+
++0.2    accept(3, ..., ...) = 4
+
++0.2    read(4, ..., 500) = 500
+
+// check the rest is OK
++0.01     <  P.  501:1501(1000)  ack 1     win 225            <nop, nop, TS val 100 ecr 100,                                         mpcapable v1 flags[flag_h] key[ckey, skey] mpcdatalen 1000, nop, nop>
++0.01     >   .  1:1(0)          ack 1501                     <nop, nop, TS val 100 ecr 100, dss dack8=1001 nocs>
+
++0.2    read(4, ..., 1000) = 1000
+
++0.2    close(4) = 0
++0.01     >   .  1:1(0)          ack 1501                     <nop, nop, TS val 100 ecr 100, dss dack8=1001 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>

--- a/gtests/net/mptcp/fastopen/server-TCP_FASTOPEN-cookie-req.pkt
+++ b/gtests/net/mptcp/fastopen/server-TCP_FASTOPEN-cookie-req.pkt
@@ -1,0 +1,37 @@
+// Receive data with TFO + cookie
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
+// A first connection to store the cookie
+ 0.0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0    getsockopt(3, SOL_TCP, TCP_FASTOPEN, [0], [4]) = 0
++0.0    setsockopt(3, SOL_TCP, TCP_FASTOPEN, [2], 4) = 0
++0.0    getsockopt(3, SOL_TCP, TCP_FASTOPEN, [2], [4]) = 0
+
++0.0    bind(3, ..., ...) = 0
++0.0    listen(3, 1) = 0
+
++0.0      <  S   0:0(0)                win 65535  <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO,            nop, nop, mpcapable v1 flags[flag_h] nokey>
++0.01     >  S.  0:0(0)      ack 1                <mss 1460, nop, nop, sackOK,           nop, wscale 8, FO TFO_COOKIE, nop, nop, mpcapable v1 flags[flag_h] key[skey]>
++0.01     <   .  1:1(0)      ack 1     win 450    <                                                                              mpcapable v1 flags[flag_h] key[ckey=2, skey]>
+
++0.2    accept(3, ..., ...) = 4
++0.2    close(4) = 0
++0.0      >   .  1:1(0)      ack 1                <dss dack4=1 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
++0.1      <   .  1:1(0)      ack 1     win 450    <dss dack4=2 dsn4=1 ssn=0 dll=1 nocs fin, nop, nop>
++0.0      >   .  1:1(0)      ack 1                <dss dack4=2 nocs>
++0.0      >  F.  1:1(0)      ack 1                <dss dack4=2 nocs>
++0.0      <   .  1:1(0)      ack 2     win 450    <dss dack4=2 nocs>
+
+// reply with a small delay to let the kernel switching to a time-wait socket.
++0.4      <  F.  1:1(0)      ack 2     win 450    <dss dack4=2 nocs>
++0.0      >   .  2:2(0)      ack 2
++0.0      <  R.  2:2(0)      ack 2     win 450
+
+
+// Not supported by Packetdrill yet: new connection
+// Another Fastopen request, now SYN will have data
++0.01     <  S   0:500(500)            win 65535  <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO TFO_COOKIE, nop, nop, mpcapable v1 flags[flag_h] nokey>
+// +0.01  >  S.  0:0(0)      ack 501              <mss 1460, sackOK, TS val 100 ecr 100, nop, wscale 8,                          mpcapable v1 flags[flag_h] key[skey]>
+// +0.01  <   .  501:501(0)  ack 1     win 450    <                                                                              mpcapable v1 flags[flag_h] key[ckey, skey]>

--- a/gtests/net/mptcp/fastopen/server-tfo-no-cookie.pkt
+++ b/gtests/net/mptcp/fastopen/server-tfo-no-cookie.pkt
@@ -1,0 +1,25 @@
+// Receive data with TFO + cookie
+--tolerance_usecs=100000
+`../common/defaults.sh
+ sysctl -q net.ipv4.tcp_fastopen=0x602`
+
+ 0.0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
+
++0.0    bind(3, ..., ...) = 0
++0.0    listen(3, 1) = 0
+
++0.0      <  S   0:500(500)               win 65535  <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO, nop, nop, mpcapable v1 flags[flag_h] nokey>
++0.01     >  S.  0:0(0)          ack 501             <mss 1460, sackOK, TS val 100 ecr 100, nop, wscale 8,               mpcapable v1 flags[flag_h] key[skey]>
++0.01     <   .  501:501(0)      ack 1    win 450    <nop, nop,         TS val 100 ecr 100,                              mpcapable v1 flags[flag_h] key[ckey=2, skey]>
+
++0.01   accept(3, ..., ...) = 4
+
+// check the rest is OK
++0.01     <  P.  501:1501(1000)  ack 1     win 225   <nop, nop, TS val 100 ecr 100, mpcapable v1 flags[flag_h] key[ckey, skey] mpcdatalen 1000, nop, nop>
++0.01     >   .  1:1(0)          ack 1501            <nop, nop, TS val 100 ecr 100, dss dack8=1001 nocs>
+
++0.2    read(4, ..., 1500) = 1500
+
++0.2    close(4) = 0
++0.01     >   .  1:1(0)          ack 1501            <nop, nop, TS val 100 ecr 700, dss dack8=1001 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>

--- a/gtests/net/tcp/fastopen/mptcp-like/server-tcp-no-cookie.pkt
+++ b/gtests/net/tcp/fastopen/mptcp-like/server-tcp-no-cookie.pkt
@@ -1,0 +1,28 @@
+// Receive data with TFO + cookie
+--tolerance_usecs=100000
+`../common/defaults.sh`
+// sysctl -q net.ipv4.tcp_fastopen=0x602`
+
+ 0.0    socket(..., SOCK_STREAM, IPPROTO_TCP) = 3
++0.0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0    setsockopt(3, SOL_TCP, TCP_FASTOPEN, [2], 4) = 0
+// note: we cannot set 0x202 above to have the no cookie mode, we need to use TCP_FASTOPEN_NO_COOKIE
++0.0    setsockopt(3, SOL_TCP, TCP_FASTOPEN_NO_COOKIE, [1], 4) = 0
+
++0.0    bind(3, ..., ...) = 0
++0.0    listen(3, 1) = 0
+
++0.0      <  S   0:500(500)               win 65535  <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO, nop, nop>
++0.01     >  S.  0:0(0)          ack 501             <mss 1460, sackOK, TS val 100 ecr 100, nop, wscale 8>
++0.01     <   .  501:501(0)      ack 1    win 450    <nop, nop,         TS val 100 ecr 100>
+
++0.01   accept(3, ..., ...) = 4
+
+// check the rest is OK
++0.01     <  P.  501:1501(1000)  ack 1     win 225   <nop, nop, TS val 100 ecr 100>
++0.01     >   .  1:1(0)          ack 1501            <nop, nop, TS val 100 ecr 100>
+
++0.01   read(4, ..., 1500) = 1500
+
++0.1    close(4) = 0
++0.01     >  F.  1:1(0)          ack 1501            <nop, nop, TS val 100 ecr 700>

--- a/gtests/net/tcp/fastopen/mptcp-like/server-tcp.pkt
+++ b/gtests/net/tcp/fastopen/mptcp-like/server-tcp.pkt
@@ -1,0 +1,28 @@
+// Receive data with TFO + cookie
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
+// A first connection to store the cookie
+ 0.0    socket(..., SOCK_STREAM, IPPROTO_TCP) = 3
++0.0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0    setsockopt(3, SOL_TCP, TCP_FASTOPEN, [2], 4) = 0
+
++0.0    bind(3, ..., ...) = 0
++0.0    listen(3, 1) = 0
+
++0.0      <  S   0:0(0)         win 65535  <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO, nop, nop>
++0.01     >  S.  0:0(0)  ack 1             <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, FO TFO_COOKIE, nop, nop>
++0.01     <   .  1:1(0)  ack 1  win 450    <nop, nop,         TS val 100 ecr 700>
+
++0.01   accept(3, ..., ...) = 4
++0.0    close(4) = 0
++0.0      >  F.  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700>
++0.0      <  F.  1:1(0)  ack 2  win 450    <nop, nop,         TS val 100 ecr 700>
++0.0      >   .  2:2(0)  ack 2             <nop, nop,         TS val 100 ecr 700>
++0.0      <  R.  2:2(0)  ack 2  win 450    <nop, nop,         TS val 100 ecr 700>
+
+// Not supported by Packetdrill yet? (it doesn't understand it is a new connection)
+// Another Fastopen request, now SYN will have data
++0.01     <  S   0:500(500)                win 65535  <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO TFO_COOKIE, nop, nop>
+// +0.01  >  S.  0:0(0)          ack 501              <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8>
+// +0.01  <   .  501:501(0)      ack 1     win 450    <nop, nop,         TS val 100 ecr 700>


### PR DESCRIPTION
Reverts multipath-tcp/packetdrill#107

When the kernel fix will be merged, we will be able to add these new tests:
- https://github.com/multipath-tcp/mptcp_net-next/issues/317
- https://patchwork.kernel.org/project/mptcp/list/?series=700384