### PR TITLE
mptcp: add_addr: increase tolerance

### DIFF
--- a/gtests/net/mptcp/add_addr/add_addr4_client.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr4_client.pkt
@@ -1,5 +1,5 @@
 // connection initiated by the kernel
---tolerance_usecs=250000
+--tolerance_usecs=350000
 `../common/defaults.sh`
 
 +0     `../common/client.sh`

--- a/gtests/net/mptcp/add_addr/add_addr4_port_client.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr4_port_client.pkt
@@ -1,5 +1,5 @@
 // connection initiated by the kernel
---tolerance_usecs=250000
+--tolerance_usecs=350000
 `../common/defaults.sh`
 
 +0     `../common/client.sh`

--- a/gtests/net/mptcp/add_addr/add_addr4_server.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr4_server.pkt
@@ -1,5 +1,5 @@
 // connection initiated by packetdrill
---tolerance_usecs=200000
+--tolerance_usecs=350000
 `../common/defaults.sh`
 
 // an address not used in packetdrill defaults

--- a/gtests/net/mptcp/add_addr/add_addr6_client.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr6_client.pkt
@@ -1,5 +1,5 @@
 // connection initiated by the kernel
---tolerance_usecs=250000
+--tolerance_usecs=350000
 `../common/defaults.sh`
 
 +0     `../common/client.sh`

--- a/gtests/net/mptcp/add_addr/add_addr6_port_client.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr6_port_client.pkt
@@ -1,5 +1,5 @@
 // connection initiated by the kernel
---tolerance_usecs=250000
+--tolerance_usecs=350000
 `../common/defaults.sh`
 
 +0     `../common/client.sh`

--- a/gtests/net/mptcp/add_addr/add_addr6_server.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr6_server.pkt
@@ -1,5 +1,5 @@
 // connection initiated by packetdrill
---tolerance_usecs=200000
+--tolerance_usecs=350000
 `../common/defaults.sh`
 
 // an address not used in packetdrill defaults

--- a/gtests/net/mptcp/add_addr/add_addr_retry_plain.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr_retry_plain.pkt
@@ -1,5 +1,5 @@
 // connection initiated by packetdrill
---tolerance_usecs=250000
+--tolerance_usecs=400000
 `../common/defaults.sh`
 
 +0     `sysctl -wq net.mptcp.add_addr_timeout=1`


### PR DESCRIPTION
The public CI often see packets being sent earlier than expected.

This is similar to commits fab205f ("mptcp: increase tolerance for ADD_ADDR echo") and 2c1c185 ("mptcp: add_addr: more tolerance for retry tests") but we need more to avoid what we judged to be false positives.

These false positives are happening too regularly, we need to increase the tolerance again. hopefully the last round (even if we could still got up to 0.5s if really needed).