### PR TITLE
mptcp: refactor passive socket initialization

### DIFF
--- a/gtests/net/mptcp/syscalls/close_before_accept.pkt
+++ b/gtests/net/mptcp/syscalls/close_before_accept.pkt
@@ -1,4 +1,4 @@
---tolerance_usecs=100000
+--tolerance_usecs=350000
 `../common/defaults.sh`
 
 +0    `../common/server.sh`
@@ -14,6 +14,8 @@
 +0.0    <  S   0:0(0)         win 65535  <mss 1460, sackOK, TS val 700 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
 +0.0    >  S.  0:0(0)  ack 1             <mss 1460, sackOK, TS val 100 ecr 700, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
 +0.0    <   .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 700 ecr 100,                mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.0    >   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700,                add_address address_id=1 addr[saddr0] hmac=auto>
+
 +0.2    <  P.  1:3(2)  ack 1  win 256    <nop, nop,         TS val 700 ecr 100,                mpcapable v1 flags[flag_h] key[skey, ckey] mpcdatalen 2, nop, nop>
 
 // MP_CAPABLE carrying data are acked with 64-bit, safer not knowing if the


### PR DESCRIPTION
As a consequence of the patch with the same title from @pabeni in the kernel, the msk will become fully established before accept() and send out the ADD_ADDR earlier.

That's the new expected behaviour when this patch is applied.

Previous experimentations have shown that sending an ADD_ADDR can take longer than expected on the CI: that's why the tolerance has been increased.

This can only be merged when the linked patch has been applied in the `export` branch.

Link: https://lore.kernel.org/r/03be07463840d00536e639f76fb0089c6f99a3ff.1673940640.git.pabeni@redhat.com