### PR TITLE
mptcp: syscall: adapt for "mptcp: fix accept vs worker race"

### DIFF
--- a/gtests/net/mptcp/syscalls/close_before_accept.pkt
+++ b/gtests/net/mptcp/syscalls/close_before_accept.pkt
@@ -29,5 +29,5 @@
 +0    poll([{fd=3, events=POLLIN, revents=POLLIN}], 1, 0) = 1
 +0    accept(3, ..., ...) = 4
 
-// no easy way to check for established status, anyhow write will just work
-+0    write(4, ..., 100) = 100
+// the msk is closed if the first subflow is closed before accept().
++0    write(4, ..., 100) = -1 (Broken pipe)


### PR DESCRIPTION
The patch "mptcp: fix accept vs worker race" from @pabeni is modifying the behaviour when the first subflow is closed before accept(): the msk is now closed and a write() will fail.

Adapt close_before_accept.pkt to this new behaviour.