### PR TITLE
mptcp: new tests to validate IP_TTL and IPV6_UNICAST_HOPS sockopts

### DIFF
--- a/gtests/net/mptcp/sockopts/ip_ttl_v4.pkt
+++ b/gtests/net/mptcp/sockopts/ip_ttl_v4.pkt
@@ -1,0 +1,25 @@
+// Send data with MSG_FASTOPEN
+--tolerance_usecs=400000
+`../common/defaults.sh`
+
+ 0.0   socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0   getsockopt(3, SOL_IP, IP_TTL, [64], [4]) = 0
++0.0   setsockopt(3, SOL_IP, IP_TTL, [1], 4) = 0
++0.0   getsockopt(3, SOL_IP, IP_TTL, [1], [4]) = 0
+
++0.0   fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
++0.0   fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+
++0.0   connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
+
++0.01    >  [ttl 1]  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++0.01    <  [ttl 1]  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.01    >  [ttl 1]   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
+
++0.0   fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
++0.0   setsockopt(3, SOL_IP, IP_TTL, [2], 4) = 0
++0.0   getsockopt(3, SOL_IP, IP_TTL, [2], [4]) = 0
+
++0.1   write(3, ..., 2) = 2
+
++0.0     >  [ttl 2]  P.  1:3(2)  ack 1             <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey] mpcdatalen 2, nop, nop>

--- a/gtests/net/mptcp/sockopts/ipv6_unicast_hops_v6.pkt
+++ b/gtests/net/mptcp/sockopts/ipv6_unicast_hops_v6.pkt
@@ -1,0 +1,25 @@
+// Send data with MSG_FASTOPEN
+--tolerance_usecs=400000
+`../common/defaults.sh`
+
+ 0.0   socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0   getsockopt(3, SOL_IPV6, IPV6_UNICAST_HOPS, [64], [4]) = 0
++0.0   setsockopt(3, SOL_IPV6, IPV6_UNICAST_HOPS, [1], 4) = 0
++0.0   getsockopt(3, SOL_IPV6, IPV6_UNICAST_HOPS, [1], [4]) = 0
+
++0.0   fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
++0.0   fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+
++0.0   connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
+
++0.01    >  [ttl 1]  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++0.01    <  [ttl 1]  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.01    >  [ttl 1]   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
+
++0.0   fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
++0.0   setsockopt(3, SOL_IPV6, IPV6_UNICAST_HOPS, [2], 4) = 0
++0.0   getsockopt(3, SOL_IPV6, IPV6_UNICAST_HOPS, [2], [4]) = 0
+
++0.1   write(3, ..., 2) = 2
+
++0.0     >  [ttl 2]  P.  1:3(2)  ack 1             <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey] mpcdatalen 2, nop, nop>

--- a/gtests/net/packetdrill/ipv6.h
+++ b/gtests/net/packetdrill/ipv6.h
@@ -57,6 +57,7 @@ struct ipv6 {
 };
 
 #ifdef linux
+#define IPV6_UNICAST_HOPS 16
 #define IPV6_HOPLIMIT   52
 #define IPV6_TCLASS	67
 #endif  /* linux */

--- a/gtests/net/packetdrill/symbols_linux.c
+++ b/gtests/net/packetdrill/symbols_linux.c
@@ -165,6 +165,7 @@ struct int_symbol platform_symbols_table[] = {
 #ifdef IPV6_MTU
 	{ IPV6_MTU,                         "IPV6_MTU"                        },
 #endif
+	{ IPV6_UNICAST_HOPS,                "IPV6_UNICAST_HOPS"               },
 	{ IPV6_TCLASS,                      "IPV6_TCLASS"                     },
 	{ IPV6_HOPLIMIT,                    "IPV6_HOPLIMIT"                   },
 


### PR DESCRIPTION
These sockopts are going to be supported with MPTCP [1], it is good to validate them with packetdrill.

The values are changed, retrieved and validated by looking at the generated packets.

The values are also modified later when the connexion is on-going.

[1] https://patchwork.kernel.org/project/mptcp/patch/20230707-mptcp-unify-sockopt-issue-353-v1-6-693e15c06646@tessares.net/