### PR TITLE
run_all: various improvements

### DIFF
--- a/gtests/net/packetdrill/in_netns.sh
+++ b/gtests/net/packetdrill/in_netns.sh
@@ -6,12 +6,23 @@ set -e
 
 readonly NETNS="ns-$(mktemp -u XXXXXX)"
 
+TCPDUMP_PID=
+
 setup() {
 	ip netns add "${NETNS}"
 	ip -netns "${NETNS}" link set lo up
+	if [ -n "${TCPDUMP_OUTPUT}" ]; then
+		ip netns exec "${NETNS}" tcpdump -i any -s 150 -w "${TCPDUMP_OUTPUT}" &
+		TCPDUMP_PID=$!
+		sleep 1
+	fi
 }
 
 cleanup() {
+	if [ -n "${TCPDUMP_PID}" ]; then
+		kill "${TCPDUMP_PID}"
+		wait "${TCPDUMP_PID}" 2>/dev/null || true
+	fi
 	ip netns del "${NETNS}"
 }
 

--- a/gtests/net/packetdrill/run_all.py
+++ b/gtests/net/packetdrill/run_all.py
@@ -119,8 +119,6 @@ class TestSet(object):
 
     time_start = time.time()
     process = subprocess.Popen(cmd, stdout=outfile, stderr=errfile, cwd=execdir)
-    if self.args['serialized']:
-      process.wait()
 
     return (process, path, variant, outfile, errfile, time_start)
 
@@ -146,7 +144,7 @@ class TestSet(object):
 
   def StartPollTestSet(self, cmds):
     """Start and wait until all tests in procs have finished or until timeout."""
-    max_in_parallel = self.args['max_in_parallel']
+    max_in_parallel = 1 if self.args['serialized'] else self.args['max_in_parallel']
     if max_in_parallel == 0 or max_in_parallel > len(cmds):
       max_in_parallel = len(cmds)
 

--- a/gtests/net/packetdrill/run_all.py
+++ b/gtests/net/packetdrill/run_all.py
@@ -50,7 +50,7 @@ class TestSet(object):
       cmd.append('-' + 'v' * (self.args['verbose'] - 1))
     cmd.append(basename)
 
-    return (cmd, execdir, path, variant)
+    return (cmd, execdir, path, variant, basename)
 
   def CmdTestIPv4(self, path):
     """Return a command to run a packetdrill test over ipv4."""
@@ -114,13 +114,19 @@ class TestSet(object):
     errfile.seek(0)
     sys.stderr.write(errfile.read())
 
-  def StartTest(self, cmd, execdir, path, variant):
+  def StartTest(self, cmd, execdir, path, variant, basename):
     """Run a packetdrill test"""
     outfile = tempfile.TemporaryFile(mode='w+')
     errfile = tempfile.TemporaryFile(mode='w+')
 
+    env = os.environ
+    if self.args['capture'] is not None:
+      fname = os.path.splitext(basename)[0] +  "_" + variant + ".pcap"
+      env = dict(env, TCPDUMP_OUTPUT=os.path.join(self.args['capture'], fname))
+
     time_start = time.time()
-    process = subprocess.Popen(cmd, stdout=outfile, stderr=errfile, cwd=execdir)
+    process = subprocess.Popen(cmd, stdout=outfile, stderr=errfile, cwd=execdir,
+                               env=env)
 
     return (process, path, variant, outfile, errfile, time_start)
 
@@ -252,6 +258,8 @@ def ParseArgs():
   """Parse commandline arguments."""
   args = argparse.ArgumentParser()
   args.add_argument('path', default='.', nargs='?')
+  args.add_argument('-c', '--capture', metavar='DIR',
+                    help='capture packets in the specified directory')
   args.add_argument('-l', '--log_on_error', action='store_true',
                     help='requires verbose')
   args.add_argument('-L', '--log_on_success', action='store_true',

--- a/gtests/net/packetdrill/run_all.py
+++ b/gtests/net/packetdrill/run_all.py
@@ -46,6 +46,8 @@ class TestSet(object):
     cmd.extend(self.default_args.split())
     if extra_args is not None:
       cmd.extend(extra_args.split())
+    if self.args['verbose'] > 1:
+      cmd.append('-' + 'v' * (self.args['verbose'] - 1))
     cmd.append(basename)
 
     return (cmd, execdir, path, variant)
@@ -259,7 +261,8 @@ def ParseArgs():
                     help="max number of tests running in parallel")
   args.add_argument('-s', '--subdirs', action='store_true')
   args.add_argument('-S', '--serialized', action='store_true')
-  args.add_argument('-v', '--verbose', action='store_true')
+  args.add_argument('-v', '--verbose', action='count', default=0,
+                    help="can be repeated to run packetdrill with -v")
   return vars(args.parse_args())
 
 

--- a/gtests/net/packetdrill/run_all.py
+++ b/gtests/net/packetdrill/run_all.py
@@ -34,8 +34,8 @@ class TestSet(object):
         tests.append(dirpath + '/' + filename)
     return sorted(tests)
 
-  def StartTest(self, path, variant, extra_args=None):
-    """Run a test using packetdrill in a subprocess."""
+  def CmdTest(self, path, variant, extra_args=None):
+    """Return a command to run a test using packetdrill in a subprocess."""
     bin_path = self.tools_path + '/' + 'packetdrill'
     nswrap_path = self.tools_path + '/' + 'in_netns.sh'
 
@@ -48,17 +48,11 @@ class TestSet(object):
       cmd.extend(extra_args.split())
     cmd.append(basename)
 
-    outfile = tempfile.TemporaryFile(mode='w+')
-    errfile = tempfile.TemporaryFile(mode='w+')
+    return (cmd, execdir, path, variant)
 
-    process = subprocess.Popen(cmd, stdout=outfile, stderr=errfile, cwd=execdir)
-    if self.args['serialized']:
-      process.wait()
-    return (process, path, variant, outfile, errfile)
-
-  def StartTestIPv4(self, path):
-    """Run a packetdrill test over ipv4."""
-    return self.StartTest(
+  def CmdTestIPv4(self, path):
+    """Return a command to run a packetdrill test over ipv4."""
+    return self.CmdTest(
         path, 'ipv4',
         ('--ip_version=ipv4 '
          '--local_ip=192.168.0.2 '
@@ -70,9 +64,9 @@ class TestSet(object):
          '-D CMSG_TYPE_RECVERR=IP_RECVERR')
     )
 
-  def StartTestIPv6(self, path):
-    """Run a packetdrill test over ipv6."""
-    return self.StartTest(
+  def CmdTestIPv6(self, path):
+    """Return a command to run a packetdrill test over ipv6."""
+    return self.CmdTest(
         path, 'ipv6',
         ('--ip_version=ipv6 --mtu=1520 '
          '--local_ip=fd3d:fa7b:d17d::0 '
@@ -83,9 +77,9 @@ class TestSet(object):
          '-D CMSG_TYPE_RECVERR=IPV6_RECVERR')
     )
 
-  def StartTestIPv4Mappedv6(self, path):
-    """Run a packetdrill test over ipv4-mapped-v6."""
-    return self.StartTest(
+  def CmdTestIPv4Mappedv6(self, path):
+    """Return a command to run a packetdrill test over ipv4-mapped-v6."""
+    return self.CmdTest(
         path, 'ipv4-mapped-v6',
         ('--ip_version=ipv4-mapped-ipv6 '
          '--local_ip=192.168.0.2 '
@@ -97,17 +91,17 @@ class TestSet(object):
          '-D CMSG_TYPE_RECVERR=IPV6_RECVERR')
     )
 
-  def StartTests(self, tests):
+  def CmdsTests(self, tests):
     """Run every test in tests in all three variants (v4, v6, v4-mapped-v6)."""
-    procs = []
+    cmds = []
     for test in tests:
       if not test.endswith('v6.pkt'):
-        procs.append(self.StartTestIPv4(test))
-        procs.append(self.StartTestIPv4Mappedv6(test))
+        cmds.append(self.CmdTestIPv4(test))
+        cmds.append(self.CmdTestIPv4Mappedv6(test))
       if not test.endswith('v4.pkt'):
-        procs.append(self.StartTestIPv6(test))
+        cmds.append(self.CmdTestIPv6(test))
 
-    return procs
+    return cmds
 
   def Log(self, outfile, errfile):
     """Print a background process's stdout and stderr streams."""
@@ -118,12 +112,22 @@ class TestSet(object):
     errfile.seek(0)
     sys.stderr.write(errfile.read())
 
-  def PollTest(self, test):
-    """Test whether a test has finished and if so record its return value."""
-    process, path, variant, outfile, errfile = test
+  def StartTest(self, cmd, execdir, path, variant):
+    """Run a packetdrill test"""
+    outfile = tempfile.TemporaryFile(mode='w+')
+    errfile = tempfile.TemporaryFile(mode='w+')
 
+    time_start = time.time()
+    process = subprocess.Popen(cmd, stdout=outfile, stderr=errfile, cwd=execdir)
+    if self.args['serialized']:
+      process.wait()
+
+    return (process, path, variant, outfile, errfile, time_start)
+
+  def PollTest(self, process, path, variant, outfile, errfile, time_start, now):
+    """Test whether a test has finished and if so record its return value."""
     if process.poll() is None:
-      return False
+      return False, now - time_start >= self.max_runtime
 
     if not process.returncode:
       self.num_pass += 1
@@ -138,18 +142,34 @@ class TestSet(object):
         if self.args['log_on_error']:
           self.Log(outfile, errfile)
 
-    return True
+    return True, False
 
-  def PollTestSet(self, procs, time_start):
-    """Wait until a,l tests in procs have finished or until timeout."""
-    while time.time() - time_start < self.max_runtime and procs:
-      time.sleep(1)
+  def StartPollTestSet(self, cmds):
+    """Start and wait until all tests in procs have finished or until timeout."""
+    max_in_parallel = self.args['max_in_parallel']
+    if max_in_parallel == 0 or max_in_parallel > len(cmds):
+      max_in_parallel = len(cmds)
+
+    procs = []
+    while len(procs) < max_in_parallel:
+      procs.append(self.StartTest(*cmds.pop(0)))
+
+    timedouts = []
+    while procs:
+      time.sleep(.1)
+      now = time.time()
       for entry in procs:
-        if self.PollTest(entry):
-          procs.remove(entry)
+        stopped, timedout = self.PollTest(*entry, now)
 
-    self.num_timedout = len(procs)
-    for proc, path, variant, outfile, errfile in procs:
+        if stopped or timedout:
+          procs.remove(entry)
+          if cmds:
+            procs.append(self.StartTest(*cmds.pop(0)))
+          if timedout:
+            timedouts.append(entry)
+
+    self.num_timedout = len(timedouts)
+    for proc, path, variant, outfile, errfile, _ in timedouts:
       try:
         proc.kill()
       except:
@@ -165,8 +185,8 @@ class TestSet(object):
     tests = self.FindTests(path)
 
     time_start = time.time()
-    procs = self.StartTests(tests)
-    self.PollTestSet(procs, time_start)
+    cmds = self.CmdsTests(tests)
+    self.StartPollTestSet(cmds)
 
     print(
         'Ran % 4d tests: % 4d passing, % 4d failing, % 4d timed out (%.2f sec): %s'     # pylint: disable=line-too-long
@@ -237,6 +257,8 @@ def ParseArgs():
   args.add_argument('-L', '--log_on_success', action='store_true',
                     help='requires verbose')
   args.add_argument('-p', '--parallelize_dirs', action='store_true')
+  args.add_argument('-P', '--max_in_parallel', metavar='N', type=int, default=0,
+                    help="max number of tests running in parallel")
   args.add_argument('-s', '--subdirs', action='store_true')
   args.add_argument('-S', '--serialized', action='store_true')
   args.add_argument('-v', '--verbose', action='store_true')


### PR DESCRIPTION
Here is a small collection of various improvements for `run_all.py` script.

The first patch limits the number of tests that can be ran in parallel. This seems now required by the public CI not to run too many tests in parallel when there is only 2 cores available and a debug kernel.

The second patch is linked to the first one, simply improving `--serialized` while at it.

The third patch is useful when you need to understand what happened: running `packetdrill` with `-v` (or more)

The fourth patch helps capturing packet traces per test for further investigation.

I suggest to first merge them here to stress these new options before upstreaming them.