### PR TITLE
packetdrill: run_all: add --dry_run mode

### DIFF
--- a/gtests/net/packetdrill/run_all.py
+++ b/gtests/net/packetdrill/run_all.py
@@ -192,6 +192,13 @@ class TestSet(object):
 
     time_start = time.time()
     cmds = self.CmdsTests(tests)
+
+    if self.args['dry_run']:
+      print('Dry-run mode:')
+      for cmd in cmds:
+        print(' '.join(cmd[0]))
+      return
+
     self.StartPollTestSet(cmds)
 
     print(
@@ -267,6 +274,7 @@ def ParseArgs():
   args.add_argument('-p', '--parallelize_dirs', action='store_true')
   args.add_argument('-P', '--max_in_parallel', metavar='N', type=int, default=0,
                     help="max number of tests running in parallel")
+  args.add_argument('--dry_run', action='store_true')
   args.add_argument('-s', '--subdirs', action='store_true')
   args.add_argument('-S', '--serialized', action='store_true')
   args.add_argument('-v', '--verbose', action='count', default=0,


### PR DESCRIPTION
It is useful to have an easy way to display the commands that are going to be used: for debugging purposes, to relaunch one specific test with different arguments or from a different environment, etc.

Now a new `--dry_run` parameter is available to only display commands and not execute anything.