### PR TITLE
packetdrill: capture: wait before ending

### DIFF
--- a/gtests/net/packetdrill/in_netns.sh
+++ b/gtests/net/packetdrill/in_netns.sh
@@ -14,12 +14,13 @@ setup() {
 	if [ -n "${TCPDUMP_OUTPUT}" ]; then
 		ip netns exec "${NETNS}" tcpdump -i any -s 150 -w "${TCPDUMP_OUTPUT}" &
 		TCPDUMP_PID=$!
-		sleep 1
+		sleep 1 # give some time to TCPDump to start
 	fi
 }
 
 cleanup() {
 	if [ -n "${TCPDUMP_PID}" ]; then
+		sleep 1 # give some time to TCPDump to process the packets
 		kill "${TCPDUMP_PID}"
 		wait "${TCPDUMP_PID}" 2>/dev/null || true
 	fi


### PR DESCRIPTION
When running very small tests with the upstream version (without MPTCP), I noticed that most of the time, TCPDump didn't have time to record all the packets.

I could see such output:

    1 packet captured
    7 packets received by filter
    0 packets dropped by kernel

So the kernel (cBPF filter) saw 7 packets but only 1 was processed by TCPDump in userspace. The .pcap file is then only containing one packet instead of 7.

A simple workaround is to wait one second before stopping TCPDump. A better solution seems much harder to implement.

I suspect that the MPTCP version is slowing down packetdrill and avoid having such issues. Still, it seems safer to wait a bit not to miss anything.