### PR TITLE
mptcp: add missing ACK on some packets

### DIFF
--- a/gtests/net/mptcp/fastclose/receive_fastclose_with_ack.pkt
+++ b/gtests/net/mptcp/fastclose/receive_fastclose_with_ack.pkt
@@ -16,14 +16,14 @@
 +0.0     >   .  1:1(0)           ack 1001                       <dss dack8=1001 nocs>
 
 // send ack fastclose with a key that should not match.
-+0       <   .  1001:1001(0)               win 450              <mp_fastclose ckey=42>
++0       <   .  1001:1001(0)     ack 1     win 450              <mp_fastclose ckey=42>
 
 // more data, expect ack
 +1.0     <  P.  1001:2001(1000)  ack 1     win 450    <nop, nop, dss dack8=1    dsn8=1001 ssn=1001 dll=1000 nocs>
 +0.0     >   .  1:1(0)           ack 2001                       <dss dack8=2001 nocs>
 
 // send another ack fastclose, this time with matching key
-+0.1     <   .  2001:2001(0)               win 450              <mp_fastclose>
++0.1     <   .  2001:2001(0)     ack 1     win 450              <mp_fastclose>
 // expect peer to reset all subflows now:
 +0.01    >  R.  1:1(0)           ack 2001                       <mp_reset 0>
 

--- a/gtests/net/mptcp/fastclose/receive_fastclose_with_ack_multi.pkt
+++ b/gtests/net/mptcp/fastclose/receive_fastclose_with_ack_multi.pkt
@@ -32,13 +32,13 @@
 +0.0    >                                .  1:1(0)        ack 1002                       <dss dack8=2002                 dll=0    nocs>
 
 // fastclose on the 2nd subflow, but old sequence numbers.
-+0.1    <                                .  1:1(0)                  win 450              <mp_fastclose>
++0.1    <                                .  1:1(0)        ack 1     win 450              <mp_fastclose>
 
 // no effect expected.
 +0.0    >                                .  1:1(0)        ack 1002                       <dss dack8=2002                 dll=0    nocs>
 
 // fastclose on the 2nd subflow, good sequence numbers.
-+0.1    <                                .  1002:1002(0)            win 450              <mp_fastclose>
++0.1    <                                .  1002:1002(0)  ack 1     win 450              <mp_fastclose>
 
 // expect peer to reset both subflows now:
 +0.0    >  addr[saddr0] > addr[caddr0]  R.  1:1(0)        ack 1001                       <mp_reset 0>


### PR DESCRIPTION
Since the kernel commit https://github.com/multipath-tcp/mptcp_net-next/commit/3d501dd326fb ("tcp: do not accept ACK of bytes we never sent"), two MPTCP fastclose tests were no longer passing because the wrong ACK number was being sent. As a result, the ACK packet was dropped and the behaviour was not the expected one.

Simply setting the correct ACK number fixes the issue.