### PR TITLE
mptcp: fix wrong merge conflict resolution

### DIFF
--- a/gtests/net/packetdrill/run_packet.c
+++ b/gtests/net/packetdrill/run_packet.c
@@ -2127,6 +2127,8 @@ static int find_or_create_socket_for_script_packet(
 		/* Is this a packet starting a new mptcp subflow? */
 		*socket = handle_mp_join_for_script_packet(state,
 							   packet, direction);
+		if (*socket != NULL)
+			return STATUS_OK;
 	} else {
 		*socket = create_socket_for_nontcp_script_packet(state, packet,
 								 direction);


### PR DESCRIPTION
The blamed commit below accidentally removed a check to find an MP Join socket quicker.

It looks like this was not causing issues with the tests (or not all the time).

Fixes: 88a6510 ("Merge remote-tracking branch 'upstream/master' into mptcp-net-next")

(Note: to be backported to maintained branches: 5.15, 6.1, 6.6.)