### PR TITLE
mptcp: add notsent_lowat support

### DIFF
--- a/gtests/net/mptcp/sockopts/sockopt_TCP_NOTSENT_LOWAT.pkt
+++ b/gtests/net/mptcp/sockopts/sockopt_TCP_NOTSENT_LOWAT.pkt
@@ -1,0 +1,55 @@
+--tolerance_usecs=100000
+`../common/defaults.sh
+sysctl -w net.ipv4.tcp_wmem="4096 50000 4194304"
+`
+
+// "inspired" by epoll_out_edge_notsent_lowat.pkt
+0.0    socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0     bind(3, ..., ...) = 0
++0     listen(3, 1) = 0
+
++0        <  S   0:0(0)                   win 8000   <mss 1024, sackOK, nop, nop, nop, wscale 0, mpcapable v1 flags[flag_h] nokey>
++0        >  S.  0:0(0)        ack 1                 <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.01     <   .  1:1(0)        ack 1      win 8000                                              <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0     accept(3, ..., ...) = 4
+
+// Set not-sent lowat to 32K.
++0     getsockopt(4, SOL_TCP, TCP_NOTSENT_LOWAT, [0], [4]) = 0
++0     setsockopt(4, SOL_TCP, TCP_NOTSENT_LOWAT, [32000], 4) = 0
++0     getsockopt(4, SOL_TCP, TCP_NOTSENT_LOWAT, [32000], [4]) = 0
+
++0     fcntl(4, F_SETFL, O_RDWR|O_NONBLOCK) = 0
++0.0   epoll_create(1) = 5
+
+// Add the FD as EPOLLET and clear all the events.
++0.0   epoll_ctl(5, EPOLL_CTL_ADD, 4, {events=EPOLLOUT|EPOLLIN|EPOLLET, fd=4}) = 0
++0.0   epoll_wait(5, {events=EPOLLOUT, fd=4}, 1, 0) = 1
++0.0   epoll_wait(5, {events=0, ptr=0}, 1, 0) = 0
+
+// We have a parital write here.
++0.0   write(4, ..., 59000) = 32000
+
+// The ack does not open up enough space to send EPOLLOUT to the user.
++0.0      >  P.  1:4001(4000)       ack 1               <dss dack4=1 dsn8=1      ssn=1     dll=4000  nocs, nop,nop>
++0.0      >  P.  4001:8001(4000)    ack 1               <dss dack4=1 dsn8=4001   ssn=4001  dll=4000  nocs, nop,nop>
+
+// Now epoll_wait should not return any event because there is no space.
++0.0   epoll_wait(5, {events=0, ptr=0}, 1, 0) = 0
+
++0.0      <   .  1:1(0)             ack 8001  win 8000  <dss dack8=8001                              nocs>
++0.0      >  P. 8001:12001(4000)    ack 1               <dss dack4=1 dsn8=8001   ssn=8001  dll=4000  nocs, nop, nop>
+// Packetdrill might try to coalesce packets here, but breaking MPTCP options: test might fail, see commit msg
++0.0      >  P. 12001:16001(4000)   ack 1               <dss dack4=1 dsn8=12001  ssn=12001 dll=4000  nocs, nop, nop>
+
+// Still blocking: 24K not sent
++0.0   epoll_wait(5, {events=0, ptr=0}, 1, 0) = 0
+
+// Now this ack opens up substantial space and we will send EPOLLOUT.
++0.0      <    .  1:1(0)            ack 16001 win 8000  <dss dack8=16001                             nocs>
++0.0      >   P.  16001:20001(4000) ack 1               <dss dack4=1 dsn8=16001  ssn=16001 dll=4000  nocs, nop, nop>
++0.0      >   P.  20001:24001(4000) ack 1               <dss dack4=1 dsn8=20001  ssn=20001 dll=4000  nocs, nop, nop>
++0.0   epoll_wait(5, {events=EPOLLOUT, fd=4}, 1, 0) = 1
+
+// EPOLLET prevents a second EPOLLOUT.
++0.0   epoll_wait(5, {events=0, ptr=0}, 1, 0) = 0


### PR DESCRIPTION
based on epoll_out_edge_notsent_lowat.pkt, with some adaptation to cope with mptcp specifics.

Note that this will cause some random failures around line 43.

The root cause is that the packetdrill core tries to aggregate eligible TCP packets and can replace the wire packet with the aggregate one to fit the drill under test.

The problem is that the aggregation support is partial/buggy: packets with the same tcp options  len, but different tcp options contents will be considered eligible for aggregation, and the aggregate packets will carry the options for the 1st pkt on the wire.

The above works e.g. with tcp stamp options, but does not work with mptcp: packets with different DSS are aggregated carrying the DSS from the 1st one. Note that this is different from what the GRO engine is doing and attempts to mimic what the TCP stack coalescing is doing. With the major difference that such coalescing merges correctly different DSS.

TL;DR: to solve the failures for good non trivial changes to the core are required, but sharing the drill early to somewhat covers the pending kernel patches