### PR TITLE
Revert "mptcp: syscall: adapt for "mptcp: fix accept vs worker race""

### DIFF
--- a/gtests/net/mptcp/syscalls/close_before_accept.pkt
+++ b/gtests/net/mptcp/syscalls/close_before_accept.pkt
@@ -29,5 +29,5 @@
 +0    poll([{fd=3, events=POLLIN, revents=POLLIN}], 1, 0) = 1
 +0    accept(3, ..., ...) = 4
 
-// the msk is closed if the first subflow is closed before accept().
-+0    write(4, ..., 100) = -1 (Broken pipe)
+// no easy way to check for established status, anyhow write will just work
++0    write(4, ..., 100) = 100


### PR DESCRIPTION
This reverts commit 7868555428db7ac02ee56faf9db65a7dd798196f.

After kernel commit 7857e35ef10e ("mptcp: get rid of msk->subflow"), it looks like we are back to the previous behaviour.

This behaviour change is unexpected, but doesn't seem harmful.