### PR TITLE
mp_capable: test MIBS for TCP fallback scenarios

### DIFF
--- a/gtests/net/mptcp/dss/mpc_with_data_server.pkt
+++ b/gtests/net/mptcp/dss/mpc_with_data_server.pkt
@@ -5,6 +5,7 @@
 +0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
 +0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
 
++0     `nstat -n`
 +0     bind(3, ..., ...) = 0
 +0     listen(3, 1) = 0
 +0       <  S   0:0(0)                  win 32792  <mss 1460, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
@@ -14,6 +15,10 @@
 
 +0.01    <  P.  1:101(100)    ack 1     win 225                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey] mpcdatalen 100, nop, nop>
 +0.01    >   .  1:1(0)        ack 101              <dss dack8=101  nocs>
+
+// test mibs
++0.01  `test $(nstat -zjs | jq '.kernel.MPTcpExtMPCapableSYNRX') -eq 1`
++0     `test $(nstat -zjs | jq '.kernel.MPTcpExtMPCapableFallbackACK') -eq 0`
 
 // send 1 data segments and ack them
 +0     write(4, ..., 1000) = 1000

--- a/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_flagB_3rd_ack.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_flagB_3rd_ack.pkt
@@ -5,12 +5,17 @@
 +0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
 +0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
 
++0     `nstat -n`
 +0     bind(3, ..., ...) = 0
 +0     listen(3, 1) = 0
 +0       <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
 +0.01    <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_b, flag_h] key[ckey=2, skey] >
 +0     accept(3, ..., ...) = 4
+
+//  test mibs
++0.01  `test $(nstat -zjs | jq '.kernel.MPTcpExtMPCapableSYNRX') -eq 1`
++0     `test $(nstat -zjs | jq '.kernel.MPTcpExtMPCapableFallbackACK') -eq 1`
 
 // ensure that traffic plane is functional and does not use DSS
 

--- a/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_flagH.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_flagH.pkt
@@ -5,12 +5,17 @@
 +0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
 +0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
 
++0     `nstat -n`
 +0     bind(3, ..., ...) = 0
 +0     listen(3, 1) = 0
 +0       <  S   0:0(0)         win 32792  <mss 1460, sackOK, nop, nop, nop, wscale 8, mpcapable v1 flags 0x0 nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8>
 +0.01    <   .  1:1(0)  ack 1  win 257
 +0     accept(3, ..., ...) = 4
+
+//  test mibs
++0.01  `test $(nstat -zjs | jq '.kernel.MPTcpExtMPCapableSYNRX') -eq 0`
++0     `test $(nstat -zjs | jq '.kernel.MPTcpExtMPCapableFallbackACK') -eq 0`
 
 // ensure that traffic plane is functional and does not use DSS
 

--- a/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_flagH_3rd_ack.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_flagH_3rd_ack.pkt
@@ -5,12 +5,17 @@
 +0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
 +0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
 
++0     `nstat -n`
 +0     bind(3, ..., ...) = 0
 +0     listen(3, 1) = 0
 +0       <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
 +0.01    <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags 0x0 key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
+
+//  test mibs
++0.01  `test $(nstat -zjs | jq '.kernel.MPTcpExtMPCapableSYNRX') -eq 1`
++0     `test $(nstat -zjs | jq '.kernel.MPTcpExtMPCapableFallbackACK') -eq 1`
 
 // ensure that traffic plane is functional and does not use DSS
 

--- a/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_nompc.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_nompc.pkt
@@ -1,4 +1,4 @@
-// test the mp_capable 'B' flag according to RFC8684 § 3.1
+// test MPTCP server against plain TCP client
 --tolerance_usecs=100000
 `../common/defaults.sh`
 
@@ -8,7 +8,7 @@
 +0     `nstat -n`
 +0     bind(3, ..., ...) = 0
 +0     listen(3, 1) = 0
-+0       <  S   0:0(0)         win 32792  <mss 1460, sackOK, nop, nop, nop, wscale 8, mpcapable v1 flags 0x41 nokey>
++0       <  S   0:0(0)         win 32792  <mss 1460, sackOK, nop, nop, nop, wscale 8>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8>
 +0.01    <   .  1:1(0)  ack 1  win 257
 +0     accept(3, ..., ...) = 4
@@ -18,7 +18,6 @@
 +0     `test $(nstat -zjs | jq '.kernel.MPTcpExtMPCapableFallbackACK') -eq 0`
 
 // ensure that traffic plane is functional and does not use DSS
-
 +0     write(4, ..., 1000) = 1000
 +0       >  P.  1:1001(1000)  ack 1
 +0       <  P.  1:501(500)    ack 1001  win 257

--- a/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_wrongver.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_wrongver.pkt
@@ -5,12 +5,17 @@
 +0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
 +0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
 
++0     `nstat -n`
 +0     bind(3, ..., ...) = 0
 +0     listen(3, 1) = 0
 +0       <  S   0:0(0)         win 32792  <mss 1460, sackOK, nop, nop, nop, wscale 8, mpcapable v0 flags[flag_h] key[ckey=2]>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8>
 +0.01    <   .  1:1(0)  ack 1  win 257
 +0     accept(3, ..., ...) = 4
+
+//  test mibs
++0.01  `test $(nstat -zjs | jq '.kernel.MPTcpExtMPCapableSYNRX') -eq 0`
++0     `test $(nstat -zjs | jq '.kernel.MPTcpExtMPCapableFallbackACK') -eq 0`
 
 // ensure that traffic plane is functional and does not use DSS
 

--- a/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_wrongver_3rd_ack.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_wrongver_3rd_ack.pkt
@@ -5,12 +5,17 @@
 +0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
 +0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
 
++0     `nstat -n`
 +0     bind(3, ..., ...) = 0
 +0     listen(3, 1) = 0
 +0       <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
 +0.01    <   .  1:1(0)  ack 1  win 257                                               <mpcapable v0 flags[flag_h] key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
+
+//  test mibs
++0.01  `test $(nstat -zjs | jq '.kernel.MPTcpExtMPCapableSYNRX') -eq 1`
++0     `test $(nstat -zjs | jq '.kernel.MPTcpExtMPCapableFallbackACK') -eq 1`
 
 // ensure that traffic plane is functional and does not use DSS
 


### PR DESCRIPTION
follow-up of upstream commit:

https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net.git/commit/?id=7a1b3490f47e88ec4cbde65f1a77a0f4bc972282