### PR TITLE
packetdrill: mptcp: fix CLang errors

### DIFF
--- a/gtests/net/packetdrill/mptcp.c
+++ b/gtests/net/packetdrill/mptcp.c
@@ -715,7 +715,7 @@ static int mp_join_syn(struct packet *packet_to_modify,
 		struct mp_join_info *mp_join_script_info,
 		unsigned direction)
 {
-	struct mp_subflow *subflow;
+	struct mp_subflow *subflow = NULL;
 	if(direction == DIRECTION_INBOUND)
 		subflow = new_subflow_inbound(packet_to_modify);
 	else if(direction == DIRECTION_OUTBOUND){
@@ -1834,13 +1834,13 @@ static struct endpoint *find_next_addr_outbound(struct packet *live_packet, stru
 			tuple.dst.port : tuple.src.port;
 	}else if(add_addr_script->length == TCPOLEN_ADD_ADDR_V4_PORT ||
 		 add_addr_script->length == TCPOLEN_ADD_ADDR_V4_PORT_HMAC){
-		if(add_addr_script->data.add_addr.ipv4_w_port.port == UNDEFINED)
+		if((s16)add_addr_script->data.add_addr.ipv4_w_port.port == UNDEFINED)
 			endpoint->port = add_addr_live->data.add_addr.ipv4_w_port.port;
 		else
 			endpoint->port = add_addr_script->data.add_addr.ipv4_w_port.port;
 	}else if(add_addr_script->length == TCPOLEN_ADD_ADDR_V6_PORT ||
 		 add_addr_script->length == TCPOLEN_ADD_ADDR_V6_PORT_HMAC){
-		if(add_addr_script->data.add_addr.ipv6_w_port.port == UNDEFINED)
+		if((s16)add_addr_script->data.add_addr.ipv6_w_port.port == UNDEFINED)
 			endpoint->port = add_addr_live->data.add_addr.ipv6_w_port.port;
 		else
 			endpoint->port = add_addr_script->data.add_addr.ipv6_w_port.port;
@@ -1884,14 +1884,14 @@ static struct endpoint *find_next_addr_inbound(struct packet *live_packet, struc
 			htons(subflow->dst_port) : htons(subflow->src_port);
 	}else if(add_addr_live->length == TCPOLEN_ADD_ADDR_V4_PORT ||
 		 add_addr_live->length == TCPOLEN_ADD_ADDR_V4_PORT_HMAC){
-		if(add_addr_script->data.add_addr.ipv4_w_port.port == UNDEFINED)
+		if((s16)add_addr_script->data.add_addr.ipv4_w_port.port == UNDEFINED)
 			endpoint->port = add_addr_script->data.add_addr.flag_E ?
 				htons(subflow->dst_port): htons(subflow->src_port);
 		else
 			endpoint->port = add_addr_script->data.add_addr.ipv4_w_port.port;
 	}else if(add_addr_live->length == TCPOLEN_ADD_ADDR_V6_PORT ||
 		 add_addr_live->length == TCPOLEN_ADD_ADDR_V6_PORT_HMAC){
-		if(add_addr_script->data.add_addr.ipv6_w_port.port == UNDEFINED)
+		if((s16)add_addr_script->data.add_addr.ipv6_w_port.port == UNDEFINED)
 			endpoint->port = add_addr_script->data.add_addr.flag_E ?
 			      htons(subflow->dst_port) : htons(subflow->src_port);
 		else
@@ -1971,7 +1971,7 @@ int mptcp_subtype_add_address(struct packet *packet_to_modify,
 			add_addr_live->data.add_addr.ipv4 = endpoint->ip.ip.v4;
 		}else if(add_addr_live->length == TCPOLEN_ADD_ADDR_V4_PORT){
 			add_addr_live->data.add_addr.ipv4_w_port.ipv4 = endpoint->ip.ip.v4;
-			if(add_addr_script->data.add_addr.ipv4_w_port.port == UNDEFINED)
+			if((s16)add_addr_script->data.add_addr.ipv4_w_port.port == UNDEFINED)
 				add_addr_live->data.add_addr.ipv4_w_port.port = endpoint->port;
 		}else if(add_addr_live->length == TCPOLEN_ADD_ADDR_V4_HMAC){
 			add_addr_live->data.add_addr.ipv4_w_hmac.ipv4 = endpoint->ip.ip.v4;
@@ -1984,7 +1984,7 @@ int mptcp_subtype_add_address(struct packet *packet_to_modify,
                                                            0);
 		}else if(add_addr_live->length == TCPOLEN_ADD_ADDR_V4_PORT_HMAC){
 			add_addr_live->data.add_addr.ipv4_w_port_hmac.ipv4 = endpoint->ip.ip.v4;
-			if(add_addr_script->data.add_addr.ipv4_w_port_hmac.port == UNDEFINED)
+			if((s16)add_addr_script->data.add_addr.ipv4_w_port_hmac.port == UNDEFINED)
 				add_addr_live->data.add_addr.ipv4_w_port_hmac.port = endpoint->port;
 			if(add_addr_script->data.add_addr.ipv4_w_port_hmac.hmac == UNDEFINED)
 				add_addr_live->data.add_addr.ipv4_w_port_hmac.hmac =
@@ -1997,7 +1997,7 @@ int mptcp_subtype_add_address(struct packet *packet_to_modify,
 			add_addr_live->data.add_addr.ipv6 = endpoint->ip.ip.v6;
 		}else if(add_addr_live->length == TCPOLEN_ADD_ADDR_V6_PORT){
 			add_addr_script->data.add_addr.ipv6_w_port.ipv6 = endpoint->ip.ip.v6;
-			if(add_addr_script->data.add_addr.ipv6_w_port.port == UNDEFINED)
+			if((s16)add_addr_script->data.add_addr.ipv6_w_port.port == UNDEFINED)
 				add_addr_live->data.add_addr.ipv6_w_port.port = endpoint->port;
 		}else if(add_addr_live->length == TCPOLEN_ADD_ADDR_V6_HMAC){
 			add_addr_script->data.add_addr.ipv6_w_hmac.ipv6 = endpoint->ip.ip.v6;
@@ -2010,7 +2010,7 @@ int mptcp_subtype_add_address(struct packet *packet_to_modify,
                                                            0);
 		}else if(add_addr_live->length == TCPOLEN_ADD_ADDR_V6_PORT_HMAC){
 			add_addr_script->data.add_addr.ipv6_w_port_hmac.ipv6 = endpoint->ip.ip.v6;
-			if(add_addr_script->data.add_addr.ipv6_w_port_hmac.port == UNDEFINED)
+			if((s16)add_addr_script->data.add_addr.ipv6_w_port_hmac.port == UNDEFINED)
 				add_addr_live->data.add_addr.ipv6_w_port_hmac.port = endpoint->port;
 			if(add_addr_script->data.add_addr.ipv6_w_port_hmac.hmac == UNDEFINED)
 				add_addr_live->data.add_addr.ipv6_w_port_hmac.hmac =
@@ -2033,7 +2033,7 @@ int mptcp_subtype_add_address(struct packet *packet_to_modify,
 			add_addr_script->data.add_addr.ipv4 = endpoint->ip.ip.v4;
 		}else if(add_addr_script->length == TCPOLEN_ADD_ADDR_V4_PORT){
 			add_addr_script->data.add_addr.ipv4_w_port.ipv4 = endpoint->ip.ip.v4;
-			if(add_addr_script->data.add_addr.ipv4_w_port.port == UNDEFINED)
+			if((s16)add_addr_script->data.add_addr.ipv4_w_port.port == UNDEFINED)
 				add_addr_script->data.add_addr.ipv4_w_port.port = endpoint->port;
 		}else if(add_addr_script->length == TCPOLEN_ADD_ADDR_V4_HMAC){
 			add_addr_script->data.add_addr.ipv4_w_hmac.ipv4 = endpoint->ip.ip.v4;
@@ -2046,7 +2046,7 @@ int mptcp_subtype_add_address(struct packet *packet_to_modify,
                                                            0);
 		}else if(add_addr_script->length == TCPOLEN_ADD_ADDR_V4_PORT_HMAC){
 			add_addr_script->data.add_addr.ipv4_w_port_hmac.ipv4 = endpoint->ip.ip.v4;
-			if(add_addr_script->data.add_addr.ipv4_w_port.port == UNDEFINED)
+			if((s16)add_addr_script->data.add_addr.ipv4_w_port.port == UNDEFINED)
 				add_addr_script->data.add_addr.ipv4_w_port.port = endpoint->port;
 			if(add_addr_script->data.add_addr.ipv4_w_port_hmac.hmac == UNDEFINED)
 				add_addr_script->data.add_addr.ipv4_w_port_hmac.hmac =
@@ -2059,7 +2059,7 @@ int mptcp_subtype_add_address(struct packet *packet_to_modify,
 			add_addr_script->data.add_addr.ipv6 = endpoint->ip.ip.v6;
 		}else if(add_addr_script->length == TCPOLEN_ADD_ADDR_V6_PORT){
 			add_addr_script->data.add_addr.ipv6_w_port.ipv6 = endpoint->ip.ip.v6;
-			if(add_addr_script->data.add_addr.ipv6_w_port.port == UNDEFINED)
+			if((s16)add_addr_script->data.add_addr.ipv6_w_port.port == UNDEFINED)
 				add_addr_script->data.add_addr.ipv6_w_port.port = endpoint->port;
 		}else if(add_addr_script->length == TCPOLEN_ADD_ADDR_V6_HMAC){
 			add_addr_script->data.add_addr.ipv6_w_hmac.ipv6 = endpoint->ip.ip.v6;
@@ -2072,7 +2072,7 @@ int mptcp_subtype_add_address(struct packet *packet_to_modify,
                                                            0);
 		}else if(add_addr_script->length == TCPOLEN_ADD_ADDR_V6_PORT_HMAC){
 			add_addr_script->data.add_addr.ipv6_w_port_hmac.ipv6 = endpoint->ip.ip.v6;
-			if(add_addr_script->data.add_addr.ipv6_w_port.port == UNDEFINED)
+			if((s16)add_addr_script->data.add_addr.ipv6_w_port.port == UNDEFINED)
 				add_addr_script->data.add_addr.ipv6_w_port.port = endpoint->port;
 			if(add_addr_script->data.add_addr.ipv6_w_port_hmac.hmac == UNDEFINED)
 				add_addr_script->data.add_addr.ipv6_w_port_hmac.hmac =

--- a/gtests/net/packetdrill/parser.y
+++ b/gtests/net/packetdrill/parser.y
@@ -714,6 +714,9 @@ struct tcp_option *dss_do_dsn_dack( int dack_type, int dack_val,
 			opt = tcp_option_new(TCPOPT_MPTCP, TCPOLEN_DSS_DACK8_DSN8);
 //		opt->data.dss.dack_dsn.dsn.dsn8 = dsn_val;
 //		opt->data.dss.dack_dsn.dack.dack8 = dack_val;
+	}else{
+		semantic_error("DACK & DSN Types are not known");
+		return NULL;
 	}
 
 	struct dack *dack_script = (struct dack*)(&opt->data.dss.dack_dsn);

--- a/gtests/net/packetdrill/queue/queue.c
+++ b/gtests/net/packetdrill/queue/queue.c
@@ -49,7 +49,7 @@ int queue_rear(queue_t *queue, void **element){
 		*element = queue->elements[queue->r-1];
 	}
 	else{
-		*element = queue->elements[QUEUE_SIZE];
+		*element = queue->elements[QUEUE_SIZE-1];
 	}
 	return STATUS_OK;
 }
@@ -110,7 +110,7 @@ int queue_rear_val(queue_t_val *queue, u64 *element){
 		*element = queue->elements[queue->r-1];
 	}
 	else{
-		*element = queue->elements[QUEUE_SIZE];
+		*element = queue->elements[QUEUE_SIZE-1];
 	}
 	return STATUS_OK;
 }


### PR DESCRIPTION
When compiling with CLang and the default options, some errors cause the build to fail:

```
  queue/queue.c:52:14: error: array index 255 is past the end of the array (that has type 'void *[255]') [-Werror,-Warray-bounds]
     52 |                 *element = queue->elements[QUEUE_SIZE];
        |                            ^               ~~~~~~~~~~
  queue/queue.h:26:2: note: array 'elements' declared here
     26 |         void *elements[QUEUE_SIZE];
        |         ^
  queue/queue.c:113:14: error: array index 255 is past the end of the array (that has type 'u64[255]' (aka 'unsigned long long[255]')) [-Werror,-Warray-bounds]
    113 |                 *element = queue->elements[QUEUE_SIZE];
        |                            ^               ~~~~~~~~~~
  queue/queue.h:50:2: note: array 'elements' declared here
     50 |         u64 elements[QUEUE_SIZE];
        |         ^
  2 errors generated.
  make: *** [<builtin>: queue/queue.o] Error 1
  make: *** Waiting for unfinished jobs....
  mptcp.c:721:10: error: variable 'subflow' is used uninitialized whenever 'if' condition is false [-Werror,-Wsometimes-uninitialized]
    721 |         else if(direction == DIRECTION_OUTBOUND){
        |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  mptcp.c:732:6: note: uninitialized use occurs here
    732 |         if(!subflow)
        |             ^~~~~~~
  mptcp.c:721:7: note: remove the 'if' if its condition is always true
    721 |         else if(direction == DIRECTION_OUTBOUND){
        |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  mptcp.c:718:28: note: initialize the variable 'subflow' to silence this warning
    718 |         struct mp_subflow *subflow;
        |                                   ^
        |                                    = NULL
  mptcp.c:1837:54: error: result of comparison of constant -1 with expression of type 'u16' (aka 'unsigned short') is always false [-Werror,-Wtautological-constant-out-of-range-compare]
   1837 |                 if(add_addr_script->data.add_addr.ipv4_w_port.port == UNDEFINED)
        |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~
  mptcp.c:1843:54: error: result of comparison of constant -1 with expression of type 'u16' (aka 'unsigned short') is always false [-Werror,-Wtautological-constant-out-of-range-compare]
   1843 |                 if(add_addr_script->data.add_addr.ipv6_w_port.port == UNDEFINED)
        |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~
  mptcp.c:1887:54: error: result of comparison of constant -1 with expression of type 'u16' (aka 'unsigned short') is always false [-Werror,-Wtautological-constant-out-of-range-compare]
   1887 |                 if(add_addr_script->data.add_addr.ipv4_w_port.port == UNDEFINED)
        |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~
  mptcp.c:1894:54: error: result of comparison of constant -1 with expression of type 'u16' (aka 'unsigned short') is always false [-Werror,-Wtautological-constant-out-of-range-compare]
   1894 |                 if(add_addr_script->data.add_addr.ipv6_w_port.port == UNDEFINED)
        |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~
  mptcp.c:1974:55: error: result of comparison of constant -1 with expression of type 'u16' (aka 'unsigned short') is always false [-Werror,-Wtautological-constant-out-of-range-compare]
   1974 |                         if(add_addr_script->data.add_addr.ipv4_w_port.port == UNDEFINED)
        |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~
  mptcp.c:1987:60: error: result of comparison of constant -1 with expression of type 'u16' (aka 'unsigned short') is always false [-Werror,-Wtautological-constant-out-of-range-compare]
   1987 |                         if(add_addr_script->data.add_addr.ipv4_w_port_hmac.port == UNDEFINED)
        |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~
  mptcp.c:2000:55: error: result of comparison of constant -1 with expression of type 'u16' (aka 'unsigned short') is always false [-Werror,-Wtautological-constant-out-of-range-compare]
   2000 |                         if(add_addr_script->data.add_addr.ipv6_w_port.port == UNDEFINED)
        |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~
  mptcp.c:2013:60: error: result of comparison of constant -1 with expression of type 'u16' (aka 'unsigned short') is always false [-Werror,-Wtautological-constant-out-of-range-compare]
   2013 |                         if(add_addr_script->data.add_addr.ipv6_w_port_hmac.port == UNDEFINED)
        |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~
  mptcp.c:2036:55: error: result of comparison of constant -1 with expression of type 'u16' (aka 'unsigned short') is always false [-Werror,-Wtautological-constant-out-of-range-compare]
   2036 |                         if(add_addr_script->data.add_addr.ipv4_w_port.port == UNDEFINED)
        |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~
  mptcp.c:2049:55: error: result of comparison of constant -1 with expression of type 'u16' (aka 'unsigned short') is always false [-Werror,-Wtautological-constant-out-of-range-compare]
   2049 |                         if(add_addr_script->data.add_addr.ipv4_w_port.port == UNDEFINED)
        |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~
  mptcp.c:2062:55: error: result of comparison of constant -1 with expression of type 'u16' (aka 'unsigned short') is always false [-Werror,-Wtautological-constant-out-of-range-compare]
   2062 |                         if(add_addr_script->data.add_addr.ipv6_w_port.port == UNDEFINED)
        |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~
  mptcp.c:2075:55: error: result of comparison of constant -1 with expression of type 'u16' (aka 'unsigned short') is always false [-Werror,-Wtautological-constant-out-of-range-compare]
   2075 |                         if(add_addr_script->data.add_addr.ipv6_w_port.port == UNDEFINED)
        |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~
  13 errors generated.
  make: *** [<builtin>: mptcp.o] Error 1
  clang -g -Wall -Werror -Wno-address-of-packed-member -c parser.c
  parser.y:710:11: error: variable 'opt' is used uninitialized whenever 'if' condition is false [-Werror,-Wsometimes-uninitialized]
    710 |         }else if(dsn_type==8 && dack_type==8){
        |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~
  parser.y:719:45: note: uninitialized use occurs here
    719 |         struct dack *dack_script = (struct dack*)(&opt->data.dss.dack_dsn);
        |                                                    ^~~
  parser.y:710:8: note: remove the 'if' if its condition is always true
    710 |         }else if(dsn_type==8 && dack_type==8){
        |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  parser.y:710:11: error: variable 'opt' is used uninitialized whenever '&&' condition is false [-Werror,-Wsometimes-uninitialized]
    710 |         }else if(dsn_type==8 && dack_type==8){
        |                  ^~~~~~~~~~~
  parser.y:719:45: note: uninitialized use occurs here
    719 |         struct dack *dack_script = (struct dack*)(&opt->data.dss.dack_dsn);
        |                                                    ^~~
  parser.y:710:11: note: remove the '&&' if its condition is always true
    710 |         }else if(dsn_type==8 && dack_type==8){
        |                  ^~~~~~~~~~~~~~
  parser.y:688:24: note: initialize the variable 'opt' to silence this warning
    688 |         struct tcp_option *opt;
        |                               ^
        |                                = NULL
  2 errors generated.
  make: *** [Makefile.common:7: parser.o] Error 1
```

It looks like all these errors could lead to real issues.

Also, setting the port (u16) to -1 looks like a bad idea, but in theory, the max (net.ipv4.ip_local_port_range) is not U16_MAX, so it looks OK.