### PR TITLE
mptcp: validate `getsockopt(TCP_IS_MPTCP)`

### DIFF
--- a/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_nompc.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_nompc.pkt
@@ -4,6 +4,7 @@
 
 +0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
 +0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0     getsockopt(3, SOL_TCP, TCP_IS_MPTCP, [1], [4]) = 0
 
 +0     `nstat -n`
 +0     bind(3, ..., ...) = 0
@@ -16,6 +17,10 @@
 //  test mibs
 +0.01  `test $(nstat -zjs | jq '.kernel.MPTcpExtMPCapableSYNRX') -eq 0`
 +0     `test $(nstat -zjs | jq '.kernel.MPTcpExtMPCapableFallbackACK') -eq 0`
+
+// Check for fallback
++0     getsockopt(3, SOL_TCP, TCP_IS_MPTCP, [1], [4]) = 0
++0     getsockopt(4, SOL_TCP, TCP_IS_MPTCP, [0], [4]) = 0
 
 // ensure that traffic plane is functional and does not use DSS
 +0     write(4, ..., 1000) = 1000

--- a/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_flagB.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_flagB.pkt
@@ -4,6 +4,7 @@
 
 0.0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
 +0.0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0    getsockopt(3, SOL_TCP, TCP_IS_MPTCP, [1], [4]) = 0
 +0.0    fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
 +0.0    fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
 
@@ -16,6 +17,9 @@
 
 +0.200  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
 +0.200  fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
+
+// Check for fallback
++0.0    getsockopt(3, SOL_TCP, TCP_IS_MPTCP, [0], [4]) = 0
 
 // ensure that traffic plane is functional and does not use DSS
 

--- a/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_flagH.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_flagH.pkt
@@ -4,6 +4,7 @@
 
 0.0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
 +0.0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0    getsockopt(3, SOL_TCP, TCP_IS_MPTCP, [1], [4]) = 0
 +0.0    fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
 +0.0    fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
 
@@ -16,6 +17,9 @@
 
 +0.200  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
 +0.200  fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
+
+// Check for fallback
++0.0    getsockopt(3, SOL_TCP, TCP_IS_MPTCP, [0], [4]) = 0
 
 // ensure that traffic plane is functional and does not use DSS
 

--- a/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_wrongver.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_wrongver.pkt
@@ -4,6 +4,7 @@
 
 0.0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
 +0.0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0    getsockopt(3, SOL_TCP, TCP_IS_MPTCP, [1], [4]) = 0
 +0.0    fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
 +0.0    fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
 
@@ -16,6 +17,9 @@
 
 +0.200  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
 +0.200  fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
+
+// Check for fallback
++0.0    getsockopt(3, SOL_TCP, TCP_IS_MPTCP, [0], [4]) = 0
 
 // ensure that traffic plane is functional and does not use DSS
 

--- a/gtests/net/mptcp/mp_capable/v1_mp_capable_bind_no_cs.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_mp_capable_bind_no_cs.pkt
@@ -10,5 +10,5 @@
 
 +0       <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.01    <   .  1:1(0)  ack 1  win 257                                               <mpcapable v0 flags[flag_h] key[ckey=2, skey]>
++0.01    <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4

--- a/gtests/net/mptcp/mp_capable/v1_mp_capable_bind_no_cs.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_mp_capable_bind_no_cs.pkt
@@ -4,6 +4,7 @@
 
 +0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
 +0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0     getsockopt(3, SOL_TCP, TCP_IS_MPTCP, [1], [4]) = 0
 
 +0     bind(3, ..., ...) = 0
 +0     listen(3, 1) = 0
@@ -12,3 +13,7 @@
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
 +0.01    <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
+
+// Check for fallback
++0     getsockopt(3, SOL_TCP, TCP_IS_MPTCP, [1], [4]) = 0
++0     getsockopt(4, SOL_TCP, TCP_IS_MPTCP, [1], [4]) = 0

--- a/gtests/net/mptcp/mp_capable/v1_mp_capable_bind_no_cs_ooo.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_mp_capable_bind_no_cs_ooo.pkt
@@ -4,6 +4,7 @@
 
 +0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
 +0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0     getsockopt(3, SOL_TCP, TCP_IS_MPTCP, [1], [4]) = 0
 
 +0     bind(3, ..., ...) = 0
 +0     listen(3, 1) = 0

--- a/gtests/net/mptcp/mp_capable/v1_mp_capable_connect_no_cs.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_mp_capable_connect_no_cs.pkt
@@ -4,6 +4,7 @@
 
 0.0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
 +0.0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0    getsockopt(3, SOL_TCP, TCP_IS_MPTCP, [1], [4]) = 0
 +0.0    fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
 +0.0    fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
 
@@ -16,3 +17,6 @@
 
 +0.200  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
 +0.200  fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
+
+// Check for fallback
++0.0    getsockopt(3, SOL_TCP, TCP_IS_MPTCP, [1], [4]) = 0

--- a/gtests/net/packetdrill/symbols_linux.c
+++ b/gtests/net/packetdrill/symbols_linux.c
@@ -197,6 +197,8 @@ struct int_symbol platform_symbols_table[] = {
 	{ TCP_CM_INQ,			    "TCP_CM_INQ"		      },
 	{ TCP_TX_DELAY,			    "TCP_TX_DELAY"		      },
 
+	{ TCP_IS_MPTCP,			    "TCP_IS_MPTCP"		      },
+
 	{ O_RDONLY,                         "O_RDONLY"                        },
 	{ O_WRONLY,                         "O_WRONLY"                        },
 	{ O_RDWR,                           "O_RDWR"                          },

--- a/gtests/net/packetdrill/tcp.h
+++ b/gtests/net/packetdrill/tcp.h
@@ -71,6 +71,8 @@
 
 #define TCP_TX_DELAY		 37
 
+#define TCP_IS_MPTCP		 43
+
 /* TODO: remove these when netinet/tcp.h has them */
 #ifndef TCPI_OPT_ECN_SEEN
 #define TCPI_OPT_ECN_SEEN	16 /* received at least one packet with ECT */


### PR DESCRIPTION
Checking for fallback in MPC test cases, on the connect, listen and accept sockets, in the different cases.

Packetdrill needs to be modified to support the new socket option.