### PR TITLE
mptcp: tfo: cookie req: remove close delay

### DIFF
--- a/gtests/net/mptcp/fastopen/server-TCP_FASTOPEN-cookie-req.pkt
+++ b/gtests/net/mptcp/fastopen/server-TCP_FASTOPEN-cookie-req.pkt
@@ -19,7 +19,7 @@
 +0.2    accept(3, ..., ...) = 4
 +0.2    close(4) = 0
 +0.0      >   .  1:1(0)      ack 1                <dss dack4=1 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
-+0.1      <   .  1:1(0)      ack 1     win 450    <dss dack4=2 dsn4=1 ssn=0 dll=1 nocs fin, nop, nop>
++0.0      <   .  1:1(0)      ack 1     win 450    <dss dack4=2 dsn4=1 ssn=0 dll=1 nocs fin, nop, nop>
 +0.0      >   .  1:1(0)      ack 1                <dss dack4=2 nocs>
 +0.0      >  F.  1:1(0)      ack 1                <dss dack4=2 nocs>
 +0.0      <   .  1:1(0)      ack 2     win 450    <dss dack4=2 nocs>


### PR DESCRIPTION
This test is unstable for a bit of time. When we get an error, it looks like it is because the kernel retransmit the DATA_FIN, and the packet at line 23 is then not the expected one:

    server-TCP_FASTOPEN-cookie-req.pkt:23: error handling packet: live packet field ipv4_total_length: expected: 48 (0x30) vs actual: 64 (0x40)
    script packet:  0.634961 . 1:1(0) ack 1 <dss dack4 3007449510 flags: A>
    actual packet:  0.629870 . 1:1(0) ack 1 win 256 <dss dack4 3007449509 dsn8 17244274742396137526 ssn 0 dll 1 no_checksum flags: MmAF,nop,nop>

The retransmission might be due to the fact the packets are injected with a delay, causing the RTO to fire, and resulting in a retransmission. Removing the delay should then help stabilising this test.