### PR TITLE
mptcp: sockopt: ip tos: remove win

### DIFF
--- a/gtests/net/mptcp/sockopts/sockopt_set_ip_tos_invalid_v4.pkt
+++ b/gtests/net/mptcp/sockopts/sockopt_set_ip_tos_invalid_v4.pkt
@@ -32,6 +32,6 @@
 +0.0  setsockopt(7, SOL_IP, IP_TOS, [7], 4) = 0
 +0.1  close(7) = 0
 
-+0.0  >  [tos 0x04]  addr[caddr0] > addr[saddr0]   .  3:3(0)  ack 1  win 256    <nop, nop,         TS val 4074418292 ecr 4074418293, dss dack4=1 dsn8=3 ssn=0 dll=1 nocs fin, nop, nop>
-+0.0  >  [tos 0x04]                                .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 4074418292 ecr 4074418293, dss dack4=1 dsn8=3 ssn=0 dll=1 nocs fin, nop, nop>
++0.0  >  [tos 0x04]  addr[caddr0] > addr[saddr0]   .  3:3(0)  ack 1             <nop, nop,         TS val 4074418292 ecr 4074418293, dss dack4=1 dsn8=3 ssn=0 dll=1 nocs fin, nop, nop>
++0.0  >  [tos 0x04]                                .  1:1(0)  ack 1             <nop, nop,         TS val 4074418292 ecr 4074418293, dss dack4=1 dsn8=3 ssn=0 dll=1 nocs fin, nop, nop>
 

--- a/gtests/net/mptcp/sockopts/sockopt_set_ip_tos_valid_v4.pkt
+++ b/gtests/net/mptcp/sockopts/sockopt_set_ip_tos_valid_v4.pkt
@@ -32,6 +32,6 @@
 +0.0  setsockopt(7, SOL_IP, IP_TOS, [4], 4) = 0
 +0.1  close(7) = 0
 
-+0.0  >  [tos 0x04]  addr[caddr0] > addr[saddr0]   .  3:3(0)  ack 1  win 256    <nop, nop,         TS val 4074418292 ecr 4074418293, dss dack4=1 dsn8=3 ssn=0 dll=1 nocs fin, nop, nop>
-+0.0  >  [tos 0x04]                                .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 4074418292 ecr 4074418293, dss dack4=1 dsn8=3 ssn=0 dll=1 nocs fin, nop, nop>
++0.0  >  [tos 0x04]  addr[caddr0] > addr[saddr0]   .  3:3(0)  ack 1             <nop, nop,         TS val 4074418292 ecr 4074418293, dss dack4=1 dsn8=3 ssn=0 dll=1 nocs fin, nop, nop>
++0.0  >  [tos 0x04]                                .  1:1(0)  ack 1             <nop, nop,         TS val 4074418292 ecr 4074418293, dss dack4=1 dsn8=3 ssn=0 dll=1 nocs fin, nop, nop>
 


### PR DESCRIPTION
The window size has recently been tweaked on the kernel side, see commit https://github.com/multipath-tcp/mptcp_net-next/commit/378979e94e953c2070acb4f0e0c98d29260bd09d ("`tcp: remove 64 KByte limit for initial tp->rcv_wnd value`"), and caused the IP TOS tests to fail because they explicitly expect a window of a certain size.

These window sizes for the outgoing packets are optional, and in fact not used anywhere else in MPTCP tests. Verified using:

    $ git grep '+\S\+\s\+> .\+win [1-9]' -- gtests/net/mptcp/

So remove these size to avoid the issue. These tests are not there to validate the window sizes, but other features.