### PR TITLE
mptcp: sockopt: cork: constant delay

### DIFF
--- a/gtests/net/mptcp/sockopts/sockopt_cork_nodelay.pkt
+++ b/gtests/net/mptcp/sockopts/sockopt_cork_nodelay.pkt
@@ -12,7 +12,7 @@
 
 +0.0     <  S   0:0(0)                win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 0,          nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
 +0.0     >  S.  0:0(0)       ack 1               <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.0     <   .  1:1(0)       ack 1    win 256    <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.01    <   .  1:1(0)       ack 1    win 256    <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
 
 // check that TCP_CORK was synced from listener
@@ -34,13 +34,13 @@
 // setting TCP_NODELAY on a socket with TCP_CORK should push pending bytes out
 +0.0   setsockopt(4, SOL_TCP, TCP_NODELAY, [1], 4) = 0
 +0.0     >  P.  81:161(80)   ack 1               <nop, nop, TS val 448955294 ecr 448955294, dss dack4=1   dsn8=81  ssn=81  dll=80  nocs, nop, nop>
-+0.1     <   .  1:1(0)       ack 161  win 256    <nop, nop, TS val 448955294 ecr 448955294, dss dack4=161 nocs>
++0.01    <   .  1:1(0)       ack 161  win 256    <nop, nop, TS val 448955294 ecr 448955294, dss dack4=161 nocs>
 
 // TCP_CORK has priority over TCP_NODELAY
 +0.0   write(4, ..., 1) = 1
 +0.01  write(4, ..., 1) = 1
 +0.2     >  P.  161:163(2)   ack 1               <nop, nop, TS val 448955294 ecr 448955294, dss dack4=1   dsn8=161 ssn=161 dll=2   nocs, nop, nop>
-+0.0     <   .  1:1(0)       ack 163  win 256    <nop, nop, TS val 448955294 ecr 448955294, dss dack4=163 nocs>
++0.01    <   .  1:1(0)       ack 163  win 256    <nop, nop, TS val 448955294 ecr 448955294, dss dack4=163 nocs>
 
 // clearing TCP_CORK on the accepted connection (TCP_NODELAY stays enabled)
 +0.01  setsockopt(4, SOL_TCP, TCP_CORK, [0], 4) = 0
@@ -50,4 +50,4 @@
 +0.01  write(4, ..., 1) = 1
 +0.0     >  P.  163:164(1)   ack 1               <nop, nop, TS val 448955294 ecr 448955294, dss dack4=1   dsn8=163 ssn=163 dll=1   nocs, nop, nop>
 +0.0     >  P.  164:165(1)   ack 1               <nop, nop, TS val 448955294 ecr 448955294, dss dack4=1   dsn8=164 ssn=164 dll=1   nocs, nop, nop>
-+0.0     <   .  1:1(0)       ack 165  win 256    <nop, nop, TS val 448955294 ecr 448955294, dss dack4=165 nocs>
++0.01    <   .  1:1(0)       ack 165  win 256    <nop, nop, TS val 448955294 ecr 448955294, dss dack4=165 nocs>


### PR DESCRIPTION
This test has failed recently:

    # sockopt_cork_nodelay.pkt:42: error handling packet: live packet payload: expected 2 bytes vs actual 80 bytes

It looks like the previous packet has been retransmitted. That can be due to the fact the injected packet has been done with a longer delay than usual. Using the same 0.01 delay as almost all other packets should avoid this issue. While at it, apply the same delay in 3 other places to have the same one all the time.