### PR TITLE
mptcp: join: client: slow down connection

### DIFF
--- a/gtests/net/mptcp/mp_join/mp_join_client.pkt
+++ b/gtests/net/mptcp/mp_join/mp_join_client.pkt
@@ -10,7 +10,7 @@
 
 +0.0  connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
 +0.0    >  addr[caddr0] > addr[saddr0]  S   0:0(0)                        <mss 1460, sackOK, TS val 4074410674 ecr 0,          nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.0    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.1    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0    >                                .  1:1(0)      ack 1             <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 +0.2  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
@@ -23,7 +23,7 @@
 
 
 +0.0    >               > addr[saddr1]  S   0:0(0)                        <mss 1460, sackOK, TS val 448955294 ecr 0,         nop, wscale 8, mp_join_syn     address_id=0 token=sha256_32(skey)>
-+0.0    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
++0.1    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
 +0.0    >                                .  1:1(0)      ack 1             <nop, nop,         TS val 448955294 ecr 448955294,                mp_join_ack                  sender_hmac=auto>
 
 +0.0    <                                .  1:1(0)      ack 1  win 256    <nop, nop,         TS val 448955294 ecr 448955294, dss dack8=3   nocs>


### PR DESCRIPTION
It looks like the 3rd ACK is sometimes retransmitted:

    # mp_join_client.pkt:31: error handling packet: live packet field ipv4_total_length: expected: 64 (0x40) vs actual: 76 (0x4c)
    # script packet:  2.419845 . 1:1(0) ack 101 <nop,nop,TS val 448955294 ecr 448955294,dss dack8 7277816997830721536 flags: Aa>
    # actual packet:  1.417775 . 1:1(0) ack 1 win 256 <nop,nop,TS val 448955297 ecr 448955294,mp_join_ack sender_hmac: 3115628641 2964227422 2084697744 4051535510 1058538763>

Slowing down the SYN+ACK reply might avoid a too aggressive retransmission.