### PR TITLE
mptcp: dss: ssn spec serv: slow down connection

### DIFF
--- a/gtests/net/mptcp/dss/dss_ssn_specified_server.pkt
+++ b/gtests/net/mptcp/dss/dss_ssn_specified_server.pkt
@@ -9,7 +9,7 @@
 +0     listen(3, 1) = 0
 +0       <  S   0:0(0)                     win 32792  <mss 1460, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)           ack 1                <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.01    <   .  1:1(0)           ack 1     win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.1     <   .  1:1(0)           ack 1     win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
 
 // send 2 data segments and ack them


### PR DESCRIPTION
It looks like the first data can be retransmitted:

    # dss_ssn_specified_server.pkt:21: error handling packet: live packet field tcp_seq: expected: 1001 (0x3e9) vs actual: 1 (0x1)
    # script packet:  0.347246 P. 1001:2001(1000) ack 1 <dss dack4 3007449509 dsn8 10972891139399815276 ssn 1001 dll 1000 no_checksum flags: MmA,nop,nop>
    # actual packet:  0.259861 P. 1:1001(1000) ack 1 win 256 <dss dack4 3007449509 dsn8 10972891139399814276 ssn 1 dll 1000 no_checksum flags: MmA,nop,nop>

Slowing down the 3rd ACK reply with the same delay as the one used later on might avoid a too aggressive retransmission.