### PR TITLE
mptcp: fastopen: client no cook: uniform delays

### DIFF
--- a/gtests/net/mptcp/fastopen/client-MSG_FASTOPEN-no-cookie.pkt
+++ b/gtests/net/mptcp/fastopen/client-MSG_FASTOPEN-no-cookie.pkt
@@ -7,14 +7,14 @@
 +0.0    fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
 +0.0    sendto(3, ..., 500, MSG_FASTOPEN, ..., ...) = 500
 
-+0.01     >  S   0:500(500)                           <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.01     <  S.  0:0(0)          ack 501   win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
-+0.01     >   .  501:501(0)      ack 1                <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
++0.0      >  S   0:500(500)                           <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++0.1      <  S.  0:0(0)          ack 501   win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.0      >   .  501:501(0)      ack 1                <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 // check the rest is OK
 +0.1    write(3, ..., 1000) = 1000
-+0.01     >  P.  501:1501(1000)  ack 1                <nop, nop, TS val 100 ecr 700, mpcapable v1 flags[flag_h] key[ckey, skey] mpcdatalen 1000, nop, nop>
-+0.01     <   .  1:1(0)          ack 1501  win 225                                  <dss dack8=1001 nocs>
++0.0      >  P.  501:1501(1000)  ack 1                <nop, nop, TS val 100 ecr 700, mpcapable v1 flags[flag_h] key[ckey, skey] mpcdatalen 1000, nop, nop>
++0.1      <   .  1:1(0)          ack 1501  win 225                                  <dss dack8=1001 nocs>
 
 +0.1    close(3) = 0
-+0.01     >   .  1501:1501(0)    ack 1                <nop, nop, TS val 100 ecr 700, dss dack4=1 dsn8=1001 ssn=0 dll=1 nocs fin, nop, nop>
++0.0      >   .  1501:1501(0)    ack 1                <nop, nop, TS val 100 ecr 700, dss dack4=1 dsn8=1001 ssn=0 dll=1 nocs fin, nop, nop>


### PR DESCRIPTION
The last packet before the data fin is sometimes retransmitted:

    # client-MSG_FASTOPEN-no-cookie.pkt:20: error handling packet: live packet payload: expected 0 bytes vs actual 1000 bytes

Using the same the delays, and 0.1 instead of 0.01 for the SYN+ACK might avoid a too aggressive retransmission.