### PR TITLE
mptcp: sockopt: ip tos: slow down connection

### DIFF
--- a/gtests/net/mptcp/sockopts/sockopt_set_ip_tos_invalid_v4.pkt
+++ b/gtests/net/mptcp/sockopts/sockopt_set_ip_tos_invalid_v4.pkt
@@ -11,7 +11,7 @@
 +0.0  connect(7, ..., ...) = -1  EINPROGRESS (Operation now in progress)
 
 +0.0  >  [tos 0x04]  addr[caddr0] > addr[saddr0]  S   0:0(0)                    <mss 1460, sackOK, TS val 4074410674 ecr 0,          nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.0  <                                           S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.1  <                                           S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0  >  [tos 0x04]                                .  1:1(0)  ack 1             <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 +0.0  fcntl(7, F_SETFL, O_RDWR) = 0   // set back to blocking
@@ -25,7 +25,7 @@
 +0.0  setsockopt(7, SOL_IP, IP_TOS, [7], 4) = 0
 
 +0.0  >  [tos 0x04]               > addr[saddr1]  S   0:0(0)                    <mss 1460, sackOK, TS val 448955294 ecr 0,         nop, wscale 8, mp_join_syn     address_id=0 token=sha256_32(skey)>
-+0.0  <                                           S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
++0.1  <                                           S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
 +0.0  >  [tos 0x04]                                .  1:1(0)  ack 1             <nop, nop,         TS val 448955294 ecr 448955294,                mp_join_ack                  sender_hmac=auto>
 +0.0  <                                            .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 448955294 ecr 448955294,   dss dack8=3   nocs>
 

--- a/gtests/net/mptcp/sockopts/sockopt_set_ip_tos_valid_v4.pkt
+++ b/gtests/net/mptcp/sockopts/sockopt_set_ip_tos_valid_v4.pkt
@@ -11,7 +11,7 @@
 +0.0  connect(7, ..., ...) = -1  EINPROGRESS (Operation now in progress)
 
 +0.0  >  [tos 0x04]  addr[caddr0] > addr[saddr0]  S   0:0(0)                    <mss 1460, sackOK, TS val 4074410674 ecr 0,          nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.0  <                                           S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.1  <                                           S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0  >  [tos 0x04]                                .  1:1(0)  ack 1             <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 +0.0  fcntl(7, F_SETFL, O_RDWR) = 0   // set back to blocking
@@ -25,7 +25,7 @@
 +0.0  setsockopt(7, SOL_IP, IP_TOS, [7], 4) = 0
 
 +0.0  >  [tos 0x04]               > addr[saddr1]  S   0:0(0)                    <mss 1460, sackOK, TS val 448955294 ecr 0,         nop, wscale 8, mp_join_syn     address_id=0 token=sha256_32(skey)>
-+0.0  <                                           S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
++0.1  <                                           S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
 +0.0  >  [tos 0x04]                                .  1:1(0)  ack 1             <nop, nop,         TS val 448955294 ecr 448955294,                mp_join_ack                  sender_hmac=auto>
 +0.0  <                                            .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 448955294 ecr 448955294,   dss dack8=3   nocs>
 


### PR DESCRIPTION
It looks like the first data can be retransmitted:

    # sockopt_set_ip_tos_valid_v4.pkt:35: error handling packet: packet is not for expected socket

Slowing down the SYN+ACK reply might avoid a too aggressive retransmission.