### PR TITLE
mptcp: mpc: slow down connection

### DIFF
--- a/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_flagB.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_flagB.pkt
@@ -12,7 +12,7 @@
 
 +0.0    connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
 +0.0      >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.0      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_b, flag_h] key[skey=2]>
++0.01     <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_b, flag_h] key[skey=2]>
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700>
 
 +0.200  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0

--- a/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_flagH.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_flagH.pkt
@@ -12,7 +12,7 @@
 
 +0.0    connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
 +0.0      >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.0      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags 0x0 key[skey=2]>
++0.01     <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags 0x0 key[skey=2]>
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700>
 
 +0.200  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0

--- a/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_wrongver.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_wrongver.pkt
@@ -12,7 +12,7 @@
 
 +0.0    connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
 +0.0      >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.0      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v0 flags[flag_h] key[ckey=3, skey=2]>
++0.01     <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v0 flags[flag_h] key[ckey=3, skey=2]>
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700>
 
 +0.200  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0

--- a/gtests/net/mptcp/mp_capable/v1_mp_capable_connect_no_cs.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_mp_capable_connect_no_cs.pkt
@@ -12,7 +12,7 @@
 
 +0.0    connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
 +0.0      >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.0      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.01     <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey] >
 
 +0.200  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0


### PR DESCRIPTION
It looks like the first data can be retransmitted:

    # v1_connect_tcpfallback_flagB.pkt:29: error handling packet: live packet payload: expected 0 bytes vs actual 1000 bytes

Slowing down the SYN+ACK reply might avoid a too aggressive retransmission from the TCP stack.