### PR TITLE
mptcp: validate `fix endpoints with 'signal' and 'subflow' flags`

### DIFF
--- a/gtests/net/mptcp/add_addr/add_addr_echo_new_sf.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr_echo_new_sf.pkt
@@ -1,0 +1,37 @@
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
++0    `../common/multi-ep.sh -e 1 -m signal -m subflow`
+
++0.0  socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0  fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
++0.0  fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+
++0.0  connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
++0.0    >  addr[caddr0] > addr[saddr0]  S   0:0(0)                        <mss 1460, sackOK, TS val 4074410674 ecr 0,          nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++0.1    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.0    >                                .  1:1(0)      ack 1             <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey, skey]>
+
++0.2  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.0  fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
+
++0.2  write(3, ..., 2) = 2
++0.0    >                               P.  1:3(2)      ack 1             <nop, nop, TS val 4074418292 ecr 4074410674,                        mpcapable v1 flags[flag_h] key[ckey, skey] mpcdatalen 2, nop, nop>
++0.1    <                                .  1:1(0)      ack 3  win 256    <nop, nop, TS val 4074418293 ecr 4074418292,       dss dack8=3   nocs>
+
++0.0    >                                .  3:3(0)      ack 1             <nop, nop, TS val 4074418294 ecr 4074410674,                      add_address addr[caddr1] hmac=auto>
+
+
++0.0    >  addr[caddr1] > addr[saddr0]  S   0:0(0)                        <mss 1460, sackOK, TS val 448955294 ecr 0,         nop, wscale 8, mp_join_syn     address_id=1 token=sha256_32(skey)>
++0.1    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack address_id=0 sender_hmac=auto>
++0.0    >                                .  1:1(0)      ack 1             <nop, nop,         TS val 448955294 ecr 448955294,                mp_join_ack                  sender_hmac=auto>
++0.1    <                                .  1:1(0)      ack 1  win 256    <nop, nop,         TS val 448955294 ecr 448955294,                add_address address_id=1 addr[caddr1] addr_echo>
+
++0.2    <                                .  1:101(100)  ack 1  win 256                      <TS val 448955294 ecr 448955294, dss dack8=3   dsn8=1 ssn=1 dll=100 nocs>
++0.0    >                                .  1:1(0)      ack 101           <nop, nop,         TS val 448955294 ecr 448955294, dss dack8=101 nocs>
++0.0  read (3, ..., 100) = 100
+
++0.1  close(3) = 0
++0.0    >  addr[caddr0] > addr[saddr0]   .  3:3(0)      ack 1             <nop, nop, TS val 4074418292 ecr 4074418293,       dss dack8=101 dsn8=3 ssn=0 dll=1 nocs fin, nop, nop>
++0.0    >                                .  1:1(0)      ack 101           <nop, nop, TS val 4074418292 ecr 4074418293,       dss dack8=101 dsn8=3 ssn=0 dll=1 nocs fin, nop, nop>

--- a/gtests/net/mptcp/common/multi-ep.sh
+++ b/gtests/net/mptcp/common/multi-ep.sh
@@ -65,7 +65,7 @@ shift $((OPTIND-1))
 
 if [[ $OPT_IP_VERSION = "ipv6" ]]; then
     if [[ $OPT_LOCAL_IP =~ (.*):([0-9a-f]+) ]]; then
-        network=64
+        network=48
     else
         echo "Failed to parse ipv6 address: $OPT_LOCAL_IP" 1>&2
         exit 1

--- a/gtests/net/mptcp/common/multi-ep.sh
+++ b/gtests/net/mptcp/common/multi-ep.sh
@@ -6,11 +6,12 @@
 
 usage() { echo "$0 [-e <endpoints>] [-m <signal|subflow>] [-b]" 1>&2; exit 1; }
 
-# create_endpoints <number of endpoints> <host number> <network number> <prefix length> <is_signal> <is_backup>
+# create_endpoints <number of endpoints> <host number> <network number> <prefix length> <is_signal> <is_subflow> <is_backup>
 create_endpoints() {
-    local host= flags= ep=1 max=$1 hn=$2 nn=$3 pl=$4 sig=${5:-0} bck=${6:-0}
+    local host= flags= ep=1 max=$1 hn=$2 nn=$3 pl=$4 sig=${5:-0} sub=${6:-0} bck=${7:-0}
 
-    [ $sig -eq 1 ] && flags=signal || flags=subflow
+    [ $sig -eq 1 ] && flags=signal
+    [ $sub -eq 1 ] && flags=${flags:+$flags }subflow
     [ $bck -eq 1 ] && flags=${flags:+$flags }backup
 
     ip mptcp endpoint flush
@@ -28,7 +29,9 @@ create_endpoints() {
 
 epmax=1
 signal=1
+subflow=0
 backup=0
+mset=0
 
 while getopts ":be:m:" o; do
     case "${o}" in
@@ -37,9 +40,14 @@ while getopts ":be:m:" o; do
         [ $epmax -ge 0 -a $epmax -le 8 ] || usage
         ;;
     m)
+        if [ $mset -eq 0 ]; then
+            mset=1
+            signal=0
+        fi
+
         case ${OPTARG} in
         signal) signal=1 ;;
-        subflow) signal=0 ;;
+        subflow) subflow=1 ;;
         *) printf "invalid param $OPTARG\n" 1>&2 ; usage
         esac
         ;;
@@ -90,4 +98,4 @@ EOF
 fi
 
 ip mptcp limits set add_addr_accepted 8 subflows 8
-create_endpoints $epmax ${BASH_REMATCH[2]} ${BASH_REMATCH[1]} $network $signal $backup
+create_endpoints $epmax ${BASH_REMATCH[2]} ${BASH_REMATCH[1]} $network $signal $subflow $backup

--- a/gtests/net/mptcp/common/multi-ep.sh
+++ b/gtests/net/mptcp/common/multi-ep.sh
@@ -8,7 +8,7 @@ usage() { echo "$0 [-e <endpoints>] [-m <signal|subflow>] [-b]" 1>&2; exit 1; }
 
 # create_endpoints <number of endpoints> <host number> <network number> <prefix length> <is_signal> <is_subflow> <is_backup>
 create_endpoints() {
-    local host= flags= ep=1 nodad= max=$1 hn=$2 nn=$3 pl=$4 sig=${5:-0} sub=${6:-0} bck=${7:-0}
+    local host= flags= ep=1 nodad= addrs=() addr= endp= max=$1 hn=$2 nn=$3 pl=$4 sig=${5:-0} sub=${6:-0} bck=${7:-0}
 
     [ $sig -eq 1 ] && flags=signal
     [ $sub -eq 1 ] && flags=${flags:+$flags }subflow
@@ -19,6 +19,7 @@ create_endpoints() {
         if [ "$OPT_IP_VERSION" = "ipv6" ]; then
             host=$(printf "%s:%x" "${nn}" "$(($(printf '%d' 0x${hn})+ep))")
             nodad="nodad"
+            addrs=($(ip -6 addr show scope global dev $OPT_LOCAL_DEV | grep "inet6" | awk '{print $2}' | tac || true))
         else
             host=${nn}$((hn+ep))
         fi
@@ -26,6 +27,17 @@ create_endpoints() {
         ip addr add $host/$pl dev $OPT_LOCAL_DEV $nodad
         ip mptcp endpoint add $host $flags
         ep=$((ep+1))
+
+        # compared to v4, with v6, the IP pref is in reverse order of their def
+        # so re-add the old addresses in the reverse order
+        for addr in "${addrs[@]}"; do
+            endp=$(ip mptcp endpoint show | grep -w "${addr%/*}" || true)
+            ip addr del ${addr} dev $OPT_LOCAL_DEV
+            ip addr add ${addr} dev $OPT_LOCAL_DEV $nodad
+            if [ -n "${endp}" ]; then
+                ip mptcp endpoint add ${endp}
+            fi
+        done
     done
 }
 

--- a/gtests/net/mptcp/common/multi-ep.sh
+++ b/gtests/net/mptcp/common/multi-ep.sh
@@ -8,7 +8,7 @@ usage() { echo "$0 [-e <endpoints>] [-m <signal|subflow>] [-b]" 1>&2; exit 1; }
 
 # create_endpoints <number of endpoints> <host number> <network number> <prefix length> <is_signal> <is_subflow> <is_backup>
 create_endpoints() {
-    local host= flags= ep=1 max=$1 hn=$2 nn=$3 pl=$4 sig=${5:-0} sub=${6:-0} bck=${7:-0}
+    local host= flags= ep=1 nodad= max=$1 hn=$2 nn=$3 pl=$4 sig=${5:-0} sub=${6:-0} bck=${7:-0}
 
     [ $sig -eq 1 ] && flags=signal
     [ $sub -eq 1 ] && flags=${flags:+$flags }subflow
@@ -18,10 +18,12 @@ create_endpoints() {
     while [ ${ep} -le ${max} ]; do
         if [ "$OPT_IP_VERSION" = "ipv6" ]; then
             host=$(printf "%s:%x" "${nn}" "$(($(printf '%d' 0x${hn})+ep))")
+            nodad="nodad"
         else
             host=${nn}$((hn+ep))
         fi
-        ip addr add $host/$pl dev $OPT_LOCAL_DEV
+
+        ip addr add $host/$pl dev $OPT_LOCAL_DEV $nodad
         ip mptcp endpoint add $host $flags
         ep=$((ep+1))
     done


### PR DESCRIPTION
This validates this series: https://lore.kernel.org/r/20240621-mptcp-pm-avail-v1-0-b692d5eb89b5@kernel.org

This includes some fixes and adaptations for `multi-ep.sh` script.