### PR TITLE
mptcp: prio: MPJ+SYN+ACK should not have the backup flag

### DIFF
--- a/gtests/net/mptcp/mp_join/mp_join_server.pkt
+++ b/gtests/net/mptcp/mp_join/mp_join_server.pkt
@@ -22,9 +22,9 @@
 +0.0    >                                .  1:1(0)  ack 3             <nop, nop,         TS val 4074418293 ecr 4074418292,                dss dack8=3 dll=0 nocs>
 
 // create subflow
-+0.0    <  addr[caddr1] > addr[saddr0]  S   0:0(0)         win 65535  <mss 1460, sackOK, TS val 448955294  ecr 0,          nop, wscale 8, mp_join_syn     backup=1 address_id=1 token=sha256_32(skey)>
-+0.0    >                               S.  0:0(0)  ack 1             <mss 1460, sackOK, TS val 448955294  ecr 448955294,  nop, wscale 8, mp_join_syn_ack backup=1 address_id=1 sender_hmac=auto>
-+0.1    <                                .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 448955294  ecr 448955294,                 mp_join_ack                           sender_hmac=auto>
++0.0    <  addr[caddr1] > addr[saddr0]  S   0:0(0)         win 65535  <mss 1460, sackOK, TS val 448955294  ecr 0,          nop, wscale 8, mp_join_syn     address_id=1 token=sha256_32(skey)>
++0.0    >                               S.  0:0(0)  ack 1             <mss 1460, sackOK, TS val 448955294  ecr 448955294,  nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
++0.1    <                                .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 448955294  ecr 448955294,                 mp_join_ack                  sender_hmac=auto>
 
 +0.0    >                                .  1:1(0)  ack 1             <nop, nop,         TS val 448955294  ecr 448955294,                 dss dack8=3 nocs>
 

--- a/gtests/net/mptcp/mp_prio/mp_prio_server.pkt
+++ b/gtests/net/mptcp/mp_prio/mp_prio_server.pkt
@@ -28,7 +28,7 @@
 
 // create subflow
 +0.0    <  addr[caddr1] > addr[saddr0]  S   0:0(0)               win 65535  <mss 1460, sackOK, TS val 448955294 ecr 0,         nop, wscale 8, mp_join_syn     backup=1 address_id=1 token=sha256_32(skey)>
-+0.0    >                               S.  0:0(0)        ack 1             <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack backup=1 address_id=0 sender_hmac=auto>
++0.0    >                               S.  0:0(0)        ack 1             <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack          address_id=0 sender_hmac=auto>
 +0.1    <                                .  1:1(0)        ack 1  win 256    <nop, nop, TS val 448955294 ecr 448955294,                        mp_join_ack sender_hmac=auto>
 +0.0    >                                .  1:1(0)        ack 1             <nop, nop, TS val 448955294 ecr 448955294,                        dss dack4=5 nocs>
 

--- a/gtests/net/mptcp/regressions/close_mpj_timeout.pkt
+++ b/gtests/net/mptcp/regressions/close_mpj_timeout.pkt
@@ -24,9 +24,9 @@ sysctl -q net.mptcp.close_timeout=1`
 +0.0     >                                .  1:1(0)           ack 1001                                       <dss dack8=1001 nocs>
 
 // create subflow
-+0.0    <  addr[caddr1] > addr[saddr0]   S   0:0(0)                     win 65535  <mss 1460, sackOK, TS val 448955294  ecr 0,          nop, wscale 8, mp_join_syn     backup=1 address_id=1 token=sha256_32(skey)>
-+0.0    >                                S.  0:0(0)           ack 1                <mss 1460, sackOK, TS val 448955294  ecr 448955294,  nop, wscale 8, mp_join_syn_ack backup=1 address_id=1 sender_hmac=auto>
-+0.1    <                                 .  1:1(0)           ack 1     win 256    <nop, nop,         TS val 448955294  ecr 448955294,                 mp_join_ack                           sender_hmac=auto>
++0.0    <  addr[caddr1] > addr[saddr0]   S   0:0(0)                     win 65535  <mss 1460, sackOK, TS val 448955294  ecr 0,          nop, wscale 8, mp_join_syn     address_id=1 token=sha256_32(skey)>
++0.0    >                                S.  0:0(0)           ack 1                <mss 1460, sackOK, TS val 448955294  ecr 448955294,  nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
++0.1    <                                 .  1:1(0)           ack 1     win 256    <nop, nop,         TS val 448955294  ecr 448955294,                 mp_join_ack                  sender_hmac=auto>
 
 // reset both subflows
 +0.0    <  addr[caddr0] > addr[saddr0]   R   1001:1001(0)     ack 1     win 0

--- a/gtests/net/mptcp/regressions/close_mpj_timeout_wakeup.pkt
+++ b/gtests/net/mptcp/regressions/close_mpj_timeout_wakeup.pkt
@@ -22,9 +22,9 @@ sysctl -q net.mptcp.close_timeout=1`
 
 
 // create subflow
-+0.0    <  addr[caddr1] > addr[saddr0]   S   0:0(0)                     win 65535  <mss 1460, sackOK, TS val 448955294  ecr 0,          nop, wscale 8, mp_join_syn     backup=1 address_id=1 token=sha256_32(skey)>
-+0.0    >                                S.  0:0(0)           ack 1                <mss 1460, sackOK, TS val 448955294  ecr 448955294,  nop, wscale 8, mp_join_syn_ack backup=1 address_id=1 sender_hmac=auto>
-+0.1    <                                 .  1:1(0)           ack 1     win 256    <nop, nop,         TS val 448955294  ecr 448955294,                 mp_join_ack                           sender_hmac=auto>
++0.0    <  addr[caddr1] > addr[saddr0]   S   0:0(0)                     win 65535  <mss 1460, sackOK, TS val 448955294  ecr 0,          nop, wscale 8, mp_join_syn     address_id=1 token=sha256_32(skey)>
++0.0    >                                S.  0:0(0)           ack 1                <mss 1460, sackOK, TS val 448955294  ecr 448955294,  nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
++0.1    <                                 .  1:1(0)           ack 1     win 256    <nop, nop,         TS val 448955294  ecr 448955294,                 mp_join_ack                  sender_hmac=auto>
 
 // reset both subflows
 +0.0    <  addr[caddr0] > addr[saddr0]   R  1:1(0)            ack 1     win 0

--- a/gtests/net/mptcp/syscalls/accept.pkt
+++ b/gtests/net/mptcp/syscalls/accept.pkt
@@ -22,9 +22,9 @@
 +0.0    >                                .  1:1(0)  ack 3             <nop, nop,         TS val 4074418293 ecr 4074418292,                dss dack8=3 dll=0 nocs>
 
 // create subflow
-+0.0    <  addr[caddr1] > addr[saddr0]  S   0:0(0)         win 65535  <mss 1460, sackOK, TS val 448955294  ecr 0,          nop, wscale 8, mp_join_syn     backup=1 address_id=2 token=sha256_32(skey)>
-+0.0    >                               S.  0:0(0)  ack 1             <mss 1460, sackOK, TS val 448955294  ecr 448955294,  nop, wscale 8, mp_join_syn_ack backup=1 address_id=0 sender_hmac=auto>
-+0.1    <                                .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 448955294  ecr 448955294,                 mp_join_ack                           sender_hmac=auto>
++0.0    <  addr[caddr1] > addr[saddr0]  S   0:0(0)         win 65535  <mss 1460, sackOK, TS val 448955294  ecr 0,          nop, wscale 8, mp_join_syn     address_id=2 token=sha256_32(skey)>
++0.0    >                               S.  0:0(0)  ack 1             <mss 1460, sackOK, TS val 448955294  ecr 448955294,  nop, wscale 8, mp_join_syn_ack address_id=0 sender_hmac=auto>
++0.1    <                                .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 448955294  ecr 448955294,                 mp_join_ack                  sender_hmac=auto>
 +0.0    >                                .  1:1(0)  ack 1             <nop, nop,         TS val 448955294  ecr 448955294,                 dss dack8=3 nocs>
 
 // no poll/accept events


### PR DESCRIPTION
This 'backup' flag should only be set if the peer sending it asked for it.

The first patch removes the use of the backup flags in all tests except the one validating this flag (`mp_prio`).

In this test, he host didn't ask for the backup flag -- no endpoint linked to this address using with the backup flag -- it is simply mirroring the one set by the other peer in the MPJ + SYN as a consequence of a bug in the kernel.

This is linked to the 'mptcp: fix inconsistent backup usage' series, and more particularly to the 'mptcp: distinguish rcv vs sent backup flag in requests' patch: https://lore.kernel.org/r/20240711-mptcp-backup-mpj-v1-0-d45506182a9e@kernel.org

(Marked as 'Draft': this PR is ready and can be reviewed, but it should only be applied after having applied the kernel series.)