### PR TITLE
mptcp: close one SF, expect a FIN back

### DIFF
--- a/gtests/net/mptcp/mp_join/mp_join_server.pkt
+++ b/gtests/net/mptcp/mp_join/mp_join_server.pkt
@@ -28,6 +28,10 @@
 
 +0.0    >                                .  1:1(0)  ack 1             <nop, nop,         TS val 448955294  ecr 448955294,                 dss dack8=3 nocs>
 
+// close subflow subflow, expect a FIN in reply
++0.0    <                               F.  1:1(0)  ack 1  win 256    <nop, nop,         TS val 448955294 ecr 448955294,                dss dack8=1 nocs>
++0.0    >                               F.  1:1(0)  ack 2             <nop, nop,         TS val 448955294 ecr 448955294,                dss dack8=3 nocs>
+
 // close connection
 +0.0    <  addr[caddr0] > addr[saddr0]  F.  3:3(0)  ack 1  win 256    <nop, nop,         TS val 4074418292 ecr 4074418293,                dss dack4=1 dsn8=3 ssn=0 dll=1 nocs fin, nop, nop>
 +0.0    <               > addr[saddr1]  F.  1:1(0)  ack 1  win 256


### PR DESCRIPTION
When a connection has multiple subflows, and one of them is being closed by sending a FIN, the kernel was not replying with a FIN+ACK back.

This bug has not been seen before, probably because the in-kernel path-manager always sends a RM_ADDR before closing the subflow, forcing the closure from the other peer.

Note: marking this as a draft: we need a fix on the kernel side, we cannot merge this yet. But the modification on Packetdrill side can already been reviewed.