### PR TITLE
mptcp: disable "close one SF, expect a FIN back"

### DIFF
--- a/gtests/net/mptcp/mp_join/mp_join_server.pkt
+++ b/gtests/net/mptcp/mp_join/mp_join_server.pkt
@@ -30,7 +30,8 @@
 
 // close subflow subflow, expect a FIN in reply
 +0.0    <                               F.  1:1(0)  ack 1  win 256    <nop, nop,         TS val 448955294 ecr 448955294,                dss dack8=1 nocs>
-+0.0    >                               F.  1:1(0)  ack 2             <nop, nop,         TS val 448955294 ecr 448955294,                dss dack8=3 nocs>
+// the FIN will be triggered by the MPTCP worker, which can be "too slow" to react, and the kernel might send a dedicated ACK first, then a FIN+ACK. Hard to validate this with packetdrill.
+// +0.0 >                               F.  1:1(0)  ack 2             <nop, nop,         TS val 448955294 ecr 448955294,                dss dack8=3 nocs>
 
 // close connection
 +0.0    <  addr[caddr0] > addr[saddr0]  F.  3:3(0)  ack 1  win 256    <nop, nop,         TS val 4074418292 ecr 4074418293,                dss dack4=1 dsn8=3 ssn=0 dll=1 nocs fin, nop, nop>


### PR DESCRIPTION
The CI running with a debug kernel config found an issue with this test: an ACK without the FIN is first sent, then a FIN+ACK.

    # mp_join_server.pkt:33: error handling packet: live packet field tcp_fin: expected: 1 (0x1) vs actual: 0 (0x0)
    # script packet:  0.704671 F. 1:1(0) ack 2 <nop,nop,TS val 448955294 ecr 448955294,dss dack8 13263177308786788775 flags: Aa>
    # actual packet:  0.704832 . 1:1(0) ack 2 win 1053 <nop,nop,TS val 448955400 ecr 448955294,dss dack8 13263177308786788775 flags: Aa>

    https://github.com/multipath-tcp/mptcp_net-next/actions/runs/10502576829

The FIN packet will be triggered by the MPTCP worker, which can be "too slow" to react, which means the kernel might or might not send a dedicated ACK first, then a FIN+ACK. Hard to validate this indeterministic behaviour with packetdrill. Delaying the injection of the FIN can help to improve the situation here, but not all the time.

That's OK to disable this check, this behaviour is also being verified by the selftests:

    https://patchwork.kernel.org/project/mptcp/patch/20240809-mptcp-pm-avail-v7-2-3d0916ba39b4@kernel.org/

Fixes: 510fa4d ("mptcp: close one SF, expect a FIN back")