### PR TITLE
mptcp: fallback to TCP after 3 MPC drop + cache

### DIFF
--- a/gtests/net/mptcp/mp_capable/v1_mp_capable_connect_drop_fallback.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_mp_capable_connect_drop_fallback.pkt
@@ -1,0 +1,27 @@
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
+0.0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0    getsockopt(3, SOL_TCP, TCP_IS_MPTCP, [1], [4]) = 0
++0.0    fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
++0.0    fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+
+// Establish connection and verify that there is a fallback to TCP.
+
++0     `nstat -n`
++0.0    connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
++0.0      >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++1.0      >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++1.0      >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
+
++1.0      >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8>
++0.01     <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8>
++0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700>
+
++0.200  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
+
+// Check for fallback
++0.0    getsockopt(3, SOL_TCP, TCP_IS_MPTCP, [0], [4]) = 0
++0.01  `test $(nstat -zjs | jq '.kernel.MPTcpExtMPCapableSYNTXDrop') -eq 1`
++0.01  `test $(nstat -zjs | jq '.kernel.MPTcpExtBlackhole') -eq 1`

--- a/gtests/net/mptcp/mp_capable/v1_mp_capable_connect_drop_fallback.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_mp_capable_connect_drop_fallback.pkt
@@ -25,3 +25,27 @@
 +0.0    getsockopt(3, SOL_TCP, TCP_IS_MPTCP, [0], [4]) = 0
 +0.01  `test $(nstat -zjs | jq '.kernel.MPTcpExtMPCapableSYNTXDrop') -eq 1`
 +0.01  `test $(nstat -zjs | jq '.kernel.MPTcpExtBlackhole') -eq 1`
+
++0.01   close(3) = 0
++0        >  F.  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700>
++0.01     <  F.  1:1(0)  ack 2  win 92     <nop, nop,         TS val 700 ecr 100>
++0        >  .   2:2(0)  ack 2             <nop, nop,         TS val 100 ecr 700>
+
+
+// Establish a new MPTCP connection and verify that there is directly a fallback to TCP.
++0.02   socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 4
++0.0    setsockopt(4, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0    getsockopt(4, SOL_TCP, TCP_IS_MPTCP, [1], [4]) = 0
++0.0    fcntl(4, F_GETFL) = 0x2 (flags O_RDWR)
++0.0    fcntl(4, F_SETFL, O_RDWR|O_NONBLOCK) = 0
++0.0    connect(4, ..., ...) = -1  EINPROGRESS (Operation now in progress)
+
++0.0      >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8>
++0.01     <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8>
++0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700>
+
++0.200  getsockopt(4, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
+
+// Check for fallback
++0.0    getsockopt(4, SOL_TCP, TCP_IS_MPTCP, [0], [4]) = 0
++0.01  `test $(nstat -zjs | jq '.kernel.MPTcpExtMPCapableSYNTXDisabled') -eq 1`


### PR DESCRIPTION
A new [series](https://lore.kernel.org/mptcp/20240902-mptcp-fallback-x-mpc-v1-0-86d9170ddff7@kernel.org/T/#u) has been recently shared to force a fallback to TCP after 3 failed MPC attempts. If the "plain" TCP connection is a success after this fallback, it likely means that MPTCP is blocked. The next connections will directly fall back to TCP.

That's what is being validated here.

See these tickets for more details:

* https://github.com/multipath-tcp/mptcp_net-next/issues/477
* https://github.com/multipath-tcp/mptcp_net-next/issues/57