### PR TITLE
mptcp: mpc: delay write to avoid retransmission

### DIFF
--- a/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_nompc.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_nompc.pkt
@@ -23,9 +23,9 @@
 +0     getsockopt(4, SOL_TCP, TCP_IS_MPTCP, [0], [4]) = 0
 
 // ensure that traffic plane is functional and does not use DSS
-+0     write(4, ..., 1000) = 1000
++0.1   write(4, ..., 1000) = 1000
 +0       >  P.  1:1001(1000)  ack 1
 +0       <   .  1:1(0)        ack 1001  win 257
-+0       <  P.  1:501(500)    ack 1001  win 257
++0.01    <  P.  1:501(500)    ack 1001  win 257
 +0       >   .  1001:1001(0)  ack 501
 +0     read(4, ..., 1000) = 500


### PR DESCRIPTION
The v1_bind_tcpfallback_nompc test recently failed because the packet from line 27 got retransmitted:

    error handling packet: live packet payload: expected 0 bytes vs actual 1000 bytes

Delay the write and the injection of the data, hopefully to avoid such retransmissions.