### PR TITLE
mptcp: sockopts: maxseg: more delay to inject pkts

### DIFF
--- a/gtests/net/mptcp/sockopts/sockopt_maxseg_mptcp.pkt
+++ b/gtests/net/mptcp/sockopts/sockopt_maxseg_mptcp.pkt
@@ -30,11 +30,11 @@
 +0.0  read (4, ..., 2) = 2
 
 +0.0  getsockopt(4, SOL_TCP, TCP_MAXSEG, [1028], [4]) = 0
-+0.0  write(4, ..., 2000) = 2000
++0.1  write(4, ..., 2000) = 2000
 
 +0.0    >                                .  1:1001(1000)     ack 3                <dss dack8=3 dsn8=1    ssn=1    dll=1000 nocs, nop, nop>
 +0.0    >                               P.  1001:2001(1000)  ack 3                <dss dack8=3 dsn8=1001 ssn=1001 dll=1000 nocs, nop, nop>
-+0.1    <                                .  3:3(0)           ack 2001  win 256    <dss dack8=2001 nocs>
++0.05   <                                .  3:3(0)           ack 2001  win 256    <dss dack8=2001 nocs>
 
 +0.0  setsockopt(4, SOL_TCP, TCP_MAXSEG, [800], 4) = 0
 +0.0  getsockopt(4, SOL_TCP, TCP_MAXSEG, [1028], [4]) = 0
@@ -42,9 +42,9 @@
 
 +0.0    >                                .  2001:3001(1000)  ack 3                <dss dack8=3 dsn8=2001 ssn=2001 dll=1000 nocs, nop, nop>
 +0.0    >                               P.  3001:4001(1000)  ack 3                <dss dack8=3 dsn8=3001 ssn=3001 dll=1000 nocs, nop, nop>
-+0.1    <                                .  3:3(0)           ack 4001  win 256    <dss dack8=4001 nocs>
++0.01   <                                .  3:3(0)           ack 4001  win 256    <dss dack8=4001 nocs>
 
 // create subflow: the MSS value in the SYN+ACK will come from the listening socket (fd: 3), not the one changed in the accepted MPTCP connection (fd: 4)
 +0.0    <  addr[caddr1] > addr[saddr0]  S   0:0(0)                     win 65535  <mss 1460, nop, nop, sackOK, nop, wscale 8, mp_join_syn     address_id=1 token=sha256_32(skey)>
 +0.0    >                               S.  0:0(0)           ack 1                <mss 1028, nop, nop, sackOK, nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
-+0.1    <                                .  1:1(0)           ack 1     win 256                                               <mp_join_ack                  sender_hmac=auto>
++0.0    <                                .  1:1(0)           ack 1     win 256                                               <mp_join_ack                  sender_hmac=auto>

--- a/gtests/net/mptcp/sockopts/sockopt_maxseg_tcp.pkt
+++ b/gtests/net/mptcp/sockopts/sockopt_maxseg_tcp.pkt
@@ -14,19 +14,19 @@
 
 +0.0    <  S   0:0(0)                     win 8000  <mss 1460, sackOK, nop, nop, nop, wscale 8>
 +0.0    >  S.  0:0(0)           ack 1               <mss 1000, nop, nop, sackOK, nop, wscale 8>
-+0.01   <   .  1:1(0)           ack 1     win 8000
++0.1    <   .  1:1(0)           ack 1     win 8000
 +0.0  accept(3, ..., ...) = 4
 
 +0.0  getsockopt(4, SOL_TCP, TCP_MAXSEG, [1000], [4]) = 0
-+0.0  write(4, ..., 2000) = 2000
++0.1  write(4, ..., 2000) = 2000
 
 +0.0    >   .  1:1001(1000)     ack 1
 +0.0    >  P.  1001:2001(1000)  ack 1
-+0.01   <   .  1:1(0)           ack 2001  win 256
++0.05   <   .  1:1(0)           ack 2001  win 256
 
 +0.0  setsockopt(4, SOL_TCP, TCP_MAXSEG, [800], 4) = 0
 +0.0  getsockopt(4, SOL_TCP, TCP_MAXSEG, [1000], [4]) = 0
-+0.0  write(4, ..., 2000) = 2000
++0.1  write(4, ..., 2000) = 2000
 
 +0.0    >   .  2001:3001(1000)  ack 1
 +0.0    >  P.  3001:4001(1000)  ack 1


### PR DESCRIPTION
The CI reported issues with sockopt_maxseg_tcp.pkt:

    # script packet:  0.065905 . 2001:3001(1000) ack 1
    # actual packet:  0.050975 P. 1001:2001(1000) ack 1 win 1055

It looks like a previous packet got retransmitted, probably due to RTO firing too quickly. Increasing the delays seen by the stack should avoid these issues.