### PR TITLE
mptcp: add delay to avoid spurious retransmissions

### DIFF
--- a/gtests/net/mptcp/dss/dss_drop_after_data_fallback_server.pkt
+++ b/gtests/net/mptcp/dss/dss_drop_after_data_fallback_server.pkt
@@ -24,7 +24,7 @@
 // The server replies with data, still thinking MPTCP is being used
 +0.0    >  P.  1:101(100)       ack 501                                                        <dss dack8=501 dsn8=1 ssn=1 dll=100 nocs, nop, nop>
 // But the client already did a fallback to TCP, because the two previous packets have been received without MPTCP options
-+0.1    <   .  501:501(0)       ack 101  win 2048
++0.05   <   .  501:501(0)       ack 101  win 2048
 
 +0.0    <  P.  501:601(100)     ack 101  win 2048
 // The server should fallback to TCP, not reset: it didn't get a DATA_ACK, nor data for more than the initial window

--- a/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_flagB.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_flagB.pkt
@@ -10,7 +10,7 @@
 +0     listen(3, 1) = 0
 +0       <  S   0:0(0)         win 32792  <mss 1460, sackOK, nop, nop, nop, wscale 8, mpcapable v1 flags 0x41 nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8>
-+0.01    <   .  1:1(0)  ack 1  win 257
++0.1     <   .  1:1(0)  ack 1  win 257
 +0     accept(3, ..., ...) = 4
 
 //  test mibs
@@ -21,7 +21,7 @@
 
 +0     write(4, ..., 1000) = 1000
 +0       >  P.  1:1001(1000)  ack 1
-+0       <   .  1:1(0)        ack 1001  win 257
++0.05    <   .  1:1(0)        ack 1001  win 257
 +0       <  P.  1:501(500)    ack 1001  win 257
 +0       >   .  1001:1001(0)  ack 501
 +0     read(4, ..., 1000) = 500


### PR DESCRIPTION
The CI reported the following issues recently:

    not ok 6 packetdrill: mptcp/dss/dss_drop_after_data_fallback_server.pkt (ipv6)
    # dss_drop_after_data_fallback_server.pkt:31: error handling packet: live packet payload: expected 0 bytes vs actual 100 bytes

    not ok 2 packetdrill: mptcp/mp_capable/v1_bind_tcpfallback_flagB.pkt (ipv4-mapped-v6)
    # v1_bind_tcpfallback_flagB.pkt:26: error handling packet: live packet payload: expected 0 bytes vs actual 1000 bytes

It looks like these issues are due to spurious retransmissions. Increasing a bit the RTT before should avoid such issues.

Link: https://github.com/multipath-tcp/mptcp_net-next/actions/runs/17200455810
Link: https://github.com/multipath-tcp/mptcp_net-next/actions/runs/17200454879