### PR TITLE
mptcp: add delay to avoid spurious retransmissions (2)

### DIFF
--- a/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_flagB_3rd_ack.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_flagB_3rd_ack.pkt
@@ -10,7 +10,7 @@
 +0     listen(3, 1) = 0
 +0       <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.01    <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_b, flag_h] key[ckey=2, skey] >
++0.1     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_b, flag_h] key[ckey=2, skey] >
 +0     accept(3, ..., ...) = 4
 
 //  test mibs
@@ -21,7 +21,7 @@
 
 +0     write(4, ..., 1000) = 1000
 +0       >  P.  1:1001(1000)  ack 1
-+0       <   .  1:1(0)        ack 1001  win 257
++0.05    <   .  1:1(0)        ack 1001  win 257
 +0       <  P.  1:501(500)    ack 1001  win 257
 +0       >   .  1001:1001(0)  ack 501
 +0     read(4, ..., 1000) = 500

--- a/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_flagH.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_flagH.pkt
@@ -10,7 +10,7 @@
 +0     listen(3, 1) = 0
 +0       <  S   0:0(0)         win 32792  <mss 1460, sackOK, nop, nop, nop, wscale 8, mpcapable v1 flags 0x0 nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8>
-+0.01    <   .  1:1(0)  ack 1  win 257
++0.1     <   .  1:1(0)  ack 1  win 257
 +0     accept(3, ..., ...) = 4
 
 //  test mibs
@@ -21,7 +21,7 @@
 
 +0     write(4, ..., 1000) = 1000
 +0       >  P.  1:1001(1000)  ack 1
-+0       <   .  1:1(0)        ack 1001  win 257
++0.05    <   .  1:1(0)        ack 1001  win 257
 +0       <  P.  1:501(500)    ack 1001  win 257
 +0       >   .  1001:1001(0)  ack 501
 +0     read(4, ..., 1000) = 500

--- a/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_flagH_3rd_ack.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_flagH_3rd_ack.pkt
@@ -10,7 +10,7 @@
 +0     listen(3, 1) = 0
 +0       <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.01    <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags 0x0 key[ckey=2, skey]>
++0.1     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags 0x0 key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
 
 //  test mibs
@@ -21,7 +21,7 @@
 
 +0     write(4, ..., 1000) = 1000
 +0       >  P.  1:1001(1000)  ack 1
-+0       <   .  1:1(0)        ack 1001  win 257
++0.05    <   .  1:1(0)        ack 1001  win 257
 +0       <  P.  1:501(500)    ack 1001  win 257
 +0       >   .  1001:1001(0)  ack 501
 +0     read(4, ..., 1000) = 500

--- a/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_wrongver.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_wrongver.pkt
@@ -10,7 +10,7 @@
 +0     listen(3, 1) = 0
 +0       <  S   0:0(0)         win 32792  <mss 1460, sackOK, nop, nop, nop, wscale 8, mpcapable v0 flags[flag_h] key[ckey=2]>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8>
-+0.01    <   .  1:1(0)  ack 1  win 257
++0.1     <   .  1:1(0)  ack 1  win 257
 +0     accept(3, ..., ...) = 4
 
 //  test mibs
@@ -21,7 +21,7 @@
 
 +0     write(4, ..., 1000) = 1000
 +0       >  P.  1:1001(1000)  ack 1
-+0       <   .  1:1(0)        ack 1001  win 257
++0.05    <   .  1:1(0)        ack 1001  win 257
 +0       <  P.  1:501(500)    ack 1001  win 257
 +0       >   .  1001:1001(0)  ack 501
 +0     read(4, ..., 1000) = 500

--- a/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_wrongver_3rd_ack.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_wrongver_3rd_ack.pkt
@@ -10,7 +10,7 @@
 +0     listen(3, 1) = 0
 +0       <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.01    <   .  1:1(0)  ack 1  win 257                                               <mpcapable v0 flags[flag_h] key[ckey=2, skey]>
++0.1     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v0 flags[flag_h] key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
 
 //  test mibs
@@ -21,7 +21,7 @@
 
 +0     write(4, ..., 1000) = 1000
 +0       >  P.  1:1001(1000)  ack 1
-+0       <   .  1:1(0)        ack 1001  win 257
++0.05    <   .  1:1(0)        ack 1001  win 257
 +0       <  P.  1:501(500)    ack 1001  win 257
 +0       >   .  1001:1001(0)  ack 501
 +0     read(4, ..., 1000) = 500


### PR DESCRIPTION
The CI reported the following issues recently:

    not ok 8 packetdrill: mptcp/mp_capable/v1_bind_tcpfallback_flagH.pkt (ipv4-mapped-v6)
    # v1_bind_tcpfallback_flagH.pkt:26: error handling packet: live packet payload: expected 0 bytes vs actual 1000 bytes

It looks like this issue is similar to the previous one, and due to spurious retransmissions. Increasing a bit the RTT before should avoid such issues.

Link: https://github.com/multipath-tcp/mptcp_net-next/actions/runs/17287133074