### PR TITLE
Revert "packetdrill: fix build issue with packet_socket_linux.c"

### DIFF
--- a/gtests/net/packetdrill/packet_socket_linux.c
+++ b/gtests/net/packetdrill/packet_socket_linux.c
@@ -43,8 +43,6 @@
 #include "ethernet.h"
 #include "logging.h"
 
-#include <linux/sockios.h>
-
 /* Number of bytes to buffer in the packet socket we use for sniffing. */
 static const int PACKET_SOCKET_RCVBUF_BYTES = 2*1024*1024;
 


### PR DESCRIPTION
This reverts commit cdd89ffdab14c8fd95a8d949ecf7bc400825b2da.

Before this revert, the same header file was included twice.
    
This commit is then no longer needed, thanks to the upstream commit from Sergey Chang, see 296fb3f ("packetdrill: fix 'error: SIOCGSTAMP undeclared'").