### PR TITLE
mptcp: propagate shutdown to subflows when possible

### DIFF
--- a/gtests/net/mptcp/dss/dss_fin_retrans_established.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_retrans_established.pkt
@@ -23,6 +23,5 @@
 
 // ACK the data_fin
 +0       <   .  2:2(0)  ack 1  win 450    <dss dack4=2 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
-+0       >   .  1:1(0)  ack 1             <dss dack4=2 nocs>
 +0       >  F.  1:1(0)  ack 1             <dss dack4=2 nocs>
 +0       <  F.  2:2(0)  ack 2  win 450    <dss dack4=2 nocs>

--- a/gtests/net/mptcp/fastopen/client-MSG_FASTOPEN.pkt
+++ b/gtests/net/mptcp/fastopen/client-MSG_FASTOPEN.pkt
@@ -14,9 +14,9 @@
 +0.01   close(3) = 0
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=1 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
 +0.01     <   .  1:1(0)  ack 1  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 dsn4=1 ssn=0 dll=1 nocs fin, nop, nop>
-+0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
 +0.0      >  F.  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
 +0.0      <   .  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
++0.0      >   .  2:2(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
 
 // reply with a small delay to let the kernel switching to a time-wait socket.
 +0.4      <  F.  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>

--- a/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_CONNECT.pkt
+++ b/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_CONNECT.pkt
@@ -15,9 +15,9 @@
 +0.01   close(3) = 0
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=1 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
 +0.0      <   .  1:1(0)  ack 1  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 dsn4=1 ssn=0 dll=1 nocs fin, nop, nop>
-+0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
 +0.0      >  F.  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
 +0.0      <   .  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
++0.0      >   .  2:2(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
 
 // reply with a small delay to let the kernel switching to a time-wait socket.
 +0.4      <  F.  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>

--- a/gtests/net/mptcp/fastopen/fastopen-invalid-buf-ptr.pkt
+++ b/gtests/net/mptcp/fastopen/fastopen-invalid-buf-ptr.pkt
@@ -17,9 +17,9 @@
 +0.01   close(3) = 0
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=1 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
 +0.01     <   .  1:1(0)  ack 1  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 dsn4=1 ssn=0 dll=1 nocs fin, nop, nop>
-+0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
 +0.0      >  F.  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
 +0.0      <   .  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
++0.0      >   .  2:2(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
 
 // reply with a small delay to let the kernel switching to a time-wait socket.
 +0.4      <  F.  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>

--- a/gtests/net/mptcp/fastopen/server-TCP_FASTOPEN-cookie-req.pkt
+++ b/gtests/net/mptcp/fastopen/server-TCP_FASTOPEN-cookie-req.pkt
@@ -20,9 +20,9 @@
 +0.2    close(4) = 0
 +0.0      >   .  1:1(0)      ack 1                <dss dack4=1 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
 +0.01     <   .  1:1(0)      ack 1     win 450    <dss dack4=2 dsn4=1 ssn=0 dll=1 nocs fin, nop, nop>
-+0.0      >   .  1:1(0)      ack 1                <dss dack4=2 nocs>
 +0.0      >  F.  1:1(0)      ack 1                <dss dack4=2 nocs>
 +0.0      <   .  1:1(0)      ack 2     win 450    <dss dack4=2 nocs>
++0.0      >   .  2:2(0)      ack 1                <dss dack4=2 nocs>
 
 // reply with a small delay to let the kernel switching to a time-wait socket.
 +0.4      <  F.  1:1(0)      ack 2     win 450    <dss dack4=2 nocs>

--- a/gtests/net/mptcp/syscalls/connect_close_full.pkt
+++ b/gtests/net/mptcp/syscalls/connect_close_full.pkt
@@ -22,9 +22,9 @@
 // incoming DATA_FIN should be acked, using 4 bytes dsn, just for more noise
 
 +0.0      <   .  1:1(0)  ack 1  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 dsn4=1 ssn=0 dll=1 nocs fin, nop, nop>
-+0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
 +0.0      >  F.  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
 +0.01     <   .  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
++0.0      >   .  2:2(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
 
 // reply with a small delay to let the kernel switching to a time-wait socket.
 +0.4      <  F.  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>


### PR DESCRIPTION
The kernel is being modified to fix an issue, and this affects when the FIN flag is set (an extra and unneeded ACK is no longer sent), see [1].

The packetdrill tests checking the end of the connection have to be adapted accordingly.

Link: https://lore.kernel.org/r/20250905-sft-mptcp-disc-err-v2-1-dfb3b6b4a877@kernel.org [1]