### PR TITLE
mptcp: close_before_accept: remove extra endpoint

### DIFF
--- a/gtests/net/mptcp/syscalls/close_before_accept.pkt
+++ b/gtests/net/mptcp/syscalls/close_before_accept.pkt
@@ -1,7 +1,7 @@
 --tolerance_usecs=350000
 `../common/defaults.sh`
 
-+0    `../common/server.sh`
++0    `../common/multi-ep.sh -e 0`
 
 +0.0  socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
 +0.0  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
@@ -14,7 +14,6 @@
 +0.0    <  S   0:0(0)         win 65535  <mss 1460, sackOK, TS val 700 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
 +0.0    >  S.  0:0(0)  ack 1             <mss 1460, sackOK, TS val 100 ecr 700, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
 +0.1    <   .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 700 ecr 100,                mpcapable v1 flags[flag_h] key[ckey=2, skey]>
-+0.0    >   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700,                add_address address_id=1 addr[saddr0] hmac=auto>
 
 +0.2    <  P.  1:3(2)  ack 1  win 256    <nop, nop,         TS val 700 ecr 100,                mpcapable v1 flags[flag_h] key[skey, ckey] mpcdatalen 2, nop, nop>
 


### PR DESCRIPTION
This test recently failed [1] because the ADD_ADDR got retransmitted:

    # close_before_accept.pkt:23: error handling packet: live packet field ipv6_payload_len: expected: 44 (0x2c) vs actual: 60 (0x3c)
    # script packet:  7.351175 . 1:1(0) ack 3 <nop,nop,TS val 100 ecr 700,dss dack8 216172782113783808 flags: Aa>
    # actual packet:  7.351166 . 1:1(0) ack 3 win 1053 <nop,nop,TS val 616 ecr 700,add_address address_id: 1 ipv6: fd3d:a0b:17d6::2 hmac: 7019336500874436005>

In this test, the server was configured with an extra endpoint, hence a first ADD_ADDR sent. But no ADD_ADDR echo got injected. Instead of adding this echo, it seems better not to add the extra endpoint, and not have to deal with ADD_ADDR's that are not relevant for this particular test.

Link: https://github.com/multipath-tcp/mptcp_net-next/actions/runs/17641769831