### PR TITLE
mptcp: mpc: delay whole connection to avoid retrans

### DIFF
--- a/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_nompc.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_bind_tcpfallback_nompc.pkt
@@ -11,7 +11,7 @@
 +0     listen(3, 1) = 0
 +0       <  S   0:0(0)         win 32792  <mss 1460, sackOK, nop, nop, nop, wscale 8>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8>
-+0.01    <   .  1:1(0)  ack 1  win 257
++0.1     <   .  1:1(0)  ack 1  win 257
 +0     accept(3, ..., ...) = 4
 
 //  test mibs
@@ -23,9 +23,9 @@
 +0     getsockopt(4, SOL_TCP, TCP_IS_MPTCP, [0], [4]) = 0
 
 // ensure that traffic plane is functional and does not use DSS
-+0.1   write(4, ..., 1000) = 1000
++0     write(4, ..., 1000) = 1000
 +0       >  P.  1:1001(1000)  ack 1
-+0       <   .  1:1(0)        ack 1001  win 257
-+0.01    <  P.  1:501(500)    ack 1001  win 257
++0.05    <   .  1:1(0)        ack 1001  win 257
++0       <  P.  1:501(500)    ack 1001  win 257
 +0       >   .  1001:1001(0)  ack 501
 +0     read(4, ..., 1000) = 500


### PR DESCRIPTION
The v1_bind_tcpfallback_nompc test recently failed because the data packet got retransmitted again:

    v1_bind_tcpfallback_nompc.pkt:30: error handling packet: live packet payload: expected 0 bytes vs actual 1000 bytes

Sync with the other tests of the same folder: delay all injected by 0.1 sec instead of 0.01, then no delay for write, but one for the injected ACK (half of the RTT).

Link: https://github.com/multipath-tcp/mptcp_net-next/actions/runs/17641698933