### PR TITLE
mptcp: mpj: dss drop after 4WHS: increase delays

### DIFF
--- a/gtests/net/mptcp/mp_join/mp_join_client_dss_drop_after_mpj.pkt
+++ b/gtests/net/mptcp/mp_join/mp_join_client_dss_drop_after_mpj.pkt
@@ -10,7 +10,7 @@
 
 +0.0  connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
 +0.0    >  addr[caddr0] > addr[saddr0]  S   0:0(0)                        <mss 1460, sackOK, TS val 4074410674 ecr 0,          nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.1    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, nop, nop, sackOK,                         nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.2    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, nop, nop, sackOK,                         nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0    >                                .  1:1(0)      ack 1             <                                                                   mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 +0.2  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
@@ -25,10 +25,10 @@
 
 // New subflow
 +0.0    >               > addr[saddr1]  S   0:0(0)                        <mss 1460, sackOK, TS val 448955294 ecr 0,         nop, wscale 8, mp_join_syn     address_id=0 token=sha256_32(skey)>
-+0.01   <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, nop, nop, sackOK,                       nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
++0.1    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, nop, nop, sackOK,                       nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
 +0.0    >                                .  1:1(0)      ack 1             <                                                                 mp_join_ack                  sender_hmac=auto>
 
-+0.0    <                                .  1:1(0)      ack 1  win 256    <dss dack8=3   nocs>
++0.05   <                                .  1:1(0)      ack 1  win 256    <dss dack8=3   nocs>
 
 // Send data on the first path (easier)
 +0.2  write(3, ..., 2) = 2
@@ -44,10 +44,10 @@
 +0.1    <  addr[saddr0] > addr[caddr0]   .  1:1(0)      ack 5  win 256
 
 // Reception of data without DSS, RST
-+0.0    <  addr[saddr0] > addr[caddr0]  P.  1:3(2)  ack 1  win 256
-+0.0    >  addr[caddr0] > addr[saddr0]  R.  7:7(0)  ack 3                 <mp_reset 6>
++0.0    <  addr[saddr0] > addr[caddr0]  P.  1:3(2)      ack 1  win 256
++0.0    >  addr[caddr0] > addr[saddr0]  R.  7:7(0)      ack 3             <mp_reset 6>
 
 // Reinjection on the other subflow
 // That's what's happening according to a packet trace, but packetdrill is now confused and looked at the wrong subflow: packet is not for expected socket
 //+0.1  >  addr[caddr0] > addr[saddr1]  P.  1:3(2)      ack 1             <dss dack4=1   dsn8=3 ssn=1 dll=2 nocs, nop, nop>
-//+0.01 <  addr[saddr1] > addr[caddr0]   .  1:1(0)      ack 3  win 256    <dss dack8=5   nocs>
+//+0.1  <  addr[saddr1] > addr[caddr0]   .  1:1(0)      ack 3  win 256    <dss dack8=5   nocs>


### PR DESCRIPTION
This test recently failed twice in our CI:

    mp_join_client_dss_drop_after_mpj.pkt:35: error handling packet: packet is not for expected socket

Increase the different delays, hoping this was due to a too low RTO.

Link: https://github.com/multipath-tcp/mptcp_net-next/actions/runs/17665873873