### PR TITLE
mptcp: remove delay to inject (DATA) FIN

### DIFF
--- a/gtests/net/mptcp/fastopen/client-MSG_FASTOPEN.pkt
+++ b/gtests/net/mptcp/fastopen/client-MSG_FASTOPEN.pkt
@@ -13,7 +13,7 @@
 
 +0.01   close(3) = 0
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=1 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
-+0.01     <   .  1:1(0)  ack 1  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 dsn4=1 ssn=0 dll=1 nocs fin, nop, nop>
++0.0      <   .  1:1(0)  ack 1  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 dsn4=1 ssn=0 dll=1 nocs fin, nop, nop>
 +0.0      >  F.  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
 +0.0      <   .  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
 +0.0      >   .  2:2(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>

--- a/gtests/net/mptcp/fastopen/fastopen-invalid-buf-ptr.pkt
+++ b/gtests/net/mptcp/fastopen/fastopen-invalid-buf-ptr.pkt
@@ -16,7 +16,7 @@
 
 +0.01   close(3) = 0
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=1 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
-+0.01     <   .  1:1(0)  ack 1  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 dsn4=1 ssn=0 dll=1 nocs fin, nop, nop>
++0.0      <   .  1:1(0)  ack 1  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 dsn4=1 ssn=0 dll=1 nocs fin, nop, nop>
 +0.0      >  F.  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
 +0.0      <   .  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
 +0.0      >   .  2:2(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>

--- a/gtests/net/mptcp/fastopen/server-TCP_FASTOPEN-cookie-req.pkt
+++ b/gtests/net/mptcp/fastopen/server-TCP_FASTOPEN-cookie-req.pkt
@@ -19,7 +19,7 @@
 +0.2    accept(3, ..., ...) = 4
 +0.2    close(4) = 0
 +0.0      >   .  1:1(0)      ack 1                <dss dack4=1 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
-+0.01     <   .  1:1(0)      ack 1     win 450    <dss dack4=2 dsn4=1 ssn=0 dll=1 nocs fin, nop, nop>
++0.0      <   .  1:1(0)      ack 1     win 450    <dss dack4=2 dsn4=1 ssn=0 dll=1 nocs fin, nop, nop>
 +0.0      >  F.  1:1(0)      ack 1                <dss dack4=2 nocs>
 +0.0      <   .  1:1(0)      ack 2     win 450    <dss dack4=2 nocs>
 +0.0      >   .  2:2(0)      ack 1                <dss dack4=2 nocs>

--- a/gtests/net/mptcp/mp_capable/v1_mp_capable_connect_drop_fallback.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_mp_capable_connect_drop_fallback.pkt
@@ -28,7 +28,7 @@
 
 +0.01   close(3) = 0
 +0        >  F.  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700>
-+0.01     <  F.  1:1(0)  ack 2  win 92     <nop, nop,         TS val 700 ecr 100>
++0        <  F.  1:1(0)  ack 2  win 92     <nop, nop,         TS val 700 ecr 100>
 +0        >  .   2:2(0)  ack 2             <nop, nop,         TS val 100 ecr 700>
 
 

--- a/gtests/net/mptcp/mp_capable/v1_mp_capable_connect_drop_fallback_no_blackhole.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_mp_capable_connect_drop_fallback_no_blackhole.pkt
@@ -31,7 +31,7 @@ sysctl -q net.mptcp.syn_retrans_before_tcp_fallback=0`
 
 +0.01   close(3) = 0
 +0        >  F.  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700>
-+0.01     <  F.  1:1(0)  ack 2  win 92     <nop, nop,         TS val 700 ecr 100>
++0        <  F.  1:1(0)  ack 2  win 92     <nop, nop,         TS val 700 ecr 100>
 +0        >  .   2:2(0)  ack 2             <nop, nop,         TS val 100 ecr 700>
 
 

--- a/gtests/net/mptcp/syscalls/connect_close_full.pkt
+++ b/gtests/net/mptcp/syscalls/connect_close_full.pkt
@@ -23,7 +23,7 @@
 
 +0.0      <   .  1:1(0)  ack 1  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 dsn4=1 ssn=0 dll=1 nocs fin, nop, nop>
 +0.0      >  F.  1:1(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
-+0.01     <   .  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
++0.0      <   .  1:1(0)  ack 2  win 450    <nop, nop,         TS val 700 ecr 100, dss dack4=2 nocs>
 +0.0      >   .  2:2(0)  ack 1             <nop, nop,         TS val 101 ecr 700, dss dack4=2 nocs>
 
 // reply with a small delay to let the kernel switching to a time-wait socket.


### PR DESCRIPTION
It is the end of the connection, better to avoid extra delay to avoid too aggressive retransmissions like this one:

    fastopen-invalid-buf-ptr.pkt:20: error handling packet: live packet field ipv4_total_length: expected: 60 (0x3c) vs actual: 76 (0x4c)
    script packet:  0.236624 F. 1:1(0) ack 1 <nop,nop,TS val 101 ecr 700,dss dack4 3007449510 flags: A>
    actual packet:  0.228071 . 1:1(0) ack 1 win 1050 <nop,nop,TS val 114 ecr 700,dss dack4 3007449509 dsn8 16808790248876672427 ssn 0 dll 1 no_checksum flags: MmAF,nop,nop>

Link: https://github.com/multipath-tcp/mptcp_net-next/actions/runs/17675976856