### PR TITLE
mptcp: more delay for tests with DATA_FIN

### DIFF
--- a/gtests/net/mptcp/dss/dss_fin_retrans_close_wait.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_retrans_close_wait.pkt
@@ -9,7 +9,7 @@
 +0     listen(3, 1) = 0
 +0       <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.01    <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.1     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
 
 // the client shutdown its side

--- a/gtests/net/mptcp/dss/dss_fin_retrans_established.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_retrans_established.pkt
@@ -9,7 +9,7 @@
 +0     listen(3, 1) = 0
 +0       <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.01    <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.1     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
 
 // server shutdown

--- a/gtests/net/mptcp/dss/dss_fin_server.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_server.pkt
@@ -9,7 +9,7 @@
 +0     listen(3, 1) = 0
 +0       <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey] >
-+0.01    <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey] >
++0.1     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey] >
 +0     accept(3, ..., ...) = 4
 
 // the client shutdown its side

--- a/gtests/net/mptcp/dss/mpc_with_data_client.pkt
+++ b/gtests/net/mptcp/dss/mpc_with_data_client.pkt
@@ -11,7 +11,7 @@
 
 +0.0    connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
 +0.0      >  S   0:0(0)                               <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.01     <  S.  0:0(0)          ack 1     win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.1      <  S.  0:0(0)          ack 1     win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0      >   .  1:1(0)          ack 1                <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 +0.200  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0

--- a/gtests/net/mptcp/fastopen/client-MSG_FASTOPEN.pkt
+++ b/gtests/net/mptcp/fastopen/client-MSG_FASTOPEN.pkt
@@ -8,7 +8,7 @@
 +0.0    sendto(3, ..., 500, MSG_FASTOPEN, ..., ...) = -1 EINPROGRESS (Operation now in progress)
 
 +0.0      >  S   0:0(0)                               <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO,          nop, nop, mpcapable v1 flags[flag_h] nokey>
-+0.01     <  S.  0:0(0)          ack 1     win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, FO abcd1234, nop, nop, mpcapable v1 flags[flag_h] key[skey=2]>
++0.1      <  S.  0:0(0)          ack 1     win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, FO abcd1234, nop, nop, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0      >   .  1:1(0)          ack 1                <nop, nop,         TS val 100 ecr 700,                                       mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 +0.01   close(3) = 0

--- a/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_CONNECT-no-cookie.pkt
+++ b/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_CONNECT-no-cookie.pkt
@@ -12,7 +12,7 @@
 +0.0    write(3, ..., 500) = 500
 
 +0.0      >  S   0:500(500)                           <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.01     <  S.  0:0(0)          ack 501   win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.1      <  S.  0:0(0)          ack 501   win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0      >   .  501:501(0)      ack 1                <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 // check the rest is OK

--- a/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_CONNECT.pkt
+++ b/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_CONNECT.pkt
@@ -9,7 +9,7 @@
 +0.0    connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
 
 +0.0      >  S   0:0(0)                               <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO,          nop, nop, mpcapable v1 flags[flag_h] nokey>
-+0.01     <  S.  0:0(0)          ack 1     win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, FO abcd1234, nop, nop, mpcapable v1 flags[flag_h] key[skey=2]>
++0.1      <  S.  0:0(0)          ack 1     win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, FO abcd1234, nop, nop, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0      >   .  1:1(0)          ack 1                <nop, nop,         TS val 100 ecr 700,                                       mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 +0.01   close(3) = 0

--- a/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_NO_COOKIE.pkt
+++ b/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_NO_COOKIE.pkt
@@ -14,7 +14,7 @@
 +0.0    write(3, ..., 500) = 500
 
 +0.0      >  S   0:500(500)                           <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.01     <  S.  0:0(0)          ack 501   win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.1      <  S.  0:0(0)          ack 501   win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0      >   .  501:501(0)      ack 1                <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 // check the rest is OK

--- a/gtests/net/mptcp/fastopen/fastopen-invalid-buf-ptr.pkt
+++ b/gtests/net/mptcp/fastopen/fastopen-invalid-buf-ptr.pkt
@@ -11,7 +11,7 @@
 +0.0    connect(3, ..., ...) = -1 EINPROGRESS (Operation is now in progress)
 
 +0.0      >  S   0:0(0)                               <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO,          nop, nop, mpcapable v1 flags[flag_h] nokey>
-+0.01     <  S.  0:0(0)          ack 1     win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, FO abcd1234, nop, nop, mpcapable v1 flags[flag_h] key[skey=2]>
++0.1      <  S.  0:0(0)          ack 1     win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, FO abcd1234, nop, nop, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0      >   .  1:1(0)          ack 1                <nop, nop,         TS val 100 ecr 700,                                       mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 +0.01   close(3) = 0

--- a/gtests/net/mptcp/fastopen/server-TCP_FASTOPEN-cookie-req.pkt
+++ b/gtests/net/mptcp/fastopen/server-TCP_FASTOPEN-cookie-req.pkt
@@ -14,7 +14,7 @@
 
 +0.0      <  S   0:0(0)                win 65535  <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO,            nop, nop, mpcapable v1 flags[flag_h] nokey>
 +0.0      >  S.  0:0(0)      ack 1                <mss 1460, nop, nop, sackOK,           nop, wscale 8, FO TFO_COOKIE, nop, nop, mpcapable v1 flags[flag_h] key[skey]>
-+0.01     <   .  1:1(0)      ack 1     win 450    <                                                                              mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.1      <   .  1:1(0)      ack 1     win 450    <                                                                              mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 
 +0.2    accept(3, ..., ...) = 4
 +0.2    close(4) = 0

--- a/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_flagB.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_flagB.pkt
@@ -12,7 +12,7 @@
 
 +0.0    connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
 +0.0      >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.01     <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_b, flag_h] key[skey=2]>
++0.1      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_b, flag_h] key[skey=2]>
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700>
 
 +0.200  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0

--- a/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_flagH.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_flagH.pkt
@@ -12,7 +12,7 @@
 
 +0.0    connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
 +0.0      >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.01     <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags 0x0 key[skey=2]>
++0.1      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags 0x0 key[skey=2]>
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700>
 
 +0.200  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0

--- a/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_wrongver.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_wrongver.pkt
@@ -12,7 +12,7 @@
 
 +0.0    connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
 +0.0      >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.01     <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v0 flags[flag_h] key[ckey=3, skey=2]>
++0.1      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v0 flags[flag_h] key[ckey=3, skey=2]>
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700>
 
 +0.200  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0

--- a/gtests/net/mptcp/mp_capable/v1_mp_capable_connect_drop_fallback.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_mp_capable_connect_drop_fallback.pkt
@@ -16,7 +16,7 @@
 +1.0      >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
 
 +1.0      >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8>
-+0.01     <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8>
++0.1      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8>
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700>
 
 +0.200  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0

--- a/gtests/net/mptcp/mp_capable/v1_mp_capable_connect_drop_fallback_no_blackhole.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_mp_capable_connect_drop_fallback_no_blackhole.pkt
@@ -19,7 +19,7 @@ sysctl -q net.mptcp.syn_retrans_before_tcp_fallback=0`
 
 // The second one does: so it should not be detected as an MPTCP blackhole
 +1.0      >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8>
-+0.01     <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8>
++0.1      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8>
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700>
 
 +0.200  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0

--- a/gtests/net/tcp/fastopen/mptcp-like/server-tcp.pkt
+++ b/gtests/net/tcp/fastopen/mptcp-like/server-tcp.pkt
@@ -11,8 +11,8 @@
 +0.0    listen(3, 1) = 0
 
 +0.0      <  S   0:0(0)         win 65535  <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO, nop, nop>
-+0.01     >  S.  0:0(0)  ack 1             <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, FO TFO_COOKIE, nop, nop>
-+0.01     <   .  1:1(0)  ack 1  win 450    <nop, nop,         TS val 100 ecr 700>
++0.0      >  S.  0:0(0)  ack 1             <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, FO TFO_COOKIE, nop, nop>
++0.1      <   .  1:1(0)  ack 1  win 450    <nop, nop,         TS val 100 ecr 700>
 
 +0.01   accept(3, ..., ...) = 4
 +0.0    close(4) = 0


### PR DESCRIPTION
Recently, the following test failed:

    server-TCP_FASTOPEN-cookie-req.pkt:23: error handling packet: live packet field ipv4_total_length: expected: 48 (0x30) vs actual: 64 (0x40)
    script packet:  0.820436 F. 1:1(0) ack 1 <dss dack4 3007449510 flags: A>
    actual packet:  0.800199 . 1:1(0) ack 1 win 1053 <dss dack4 3007449509 dsn8 13788091865479172646 ssn 0 dll 1 no_checksum flags: MmAF,nop,nop>

The packets around there are supposed to be injected directly, but they were with a delay.

Increase the whole connection RTO to avoid such issue, and do the same for all tests looking at the packets at the end of a connection, with FIN and DATA_FIN.

Link: https://github.com/multipath-tcp/mptcp_net-next/actions/runs/17756052704