### PR TITLE
mptcp-level zero window probe test

### DIFF
--- a/gtests/net/mptcp/dss/mpc_with_data_server_window_close.pkt
+++ b/gtests/net/mptcp/dss/mpc_with_data_server_window_close.pkt
@@ -1,0 +1,32 @@
+// connection initiated by packetdrill
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
++0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
+
++0     `nstat -n`
++0     bind(3, ..., ...) = 0
++0     listen(3, 1) = 0
++0         <  S   0:0(0)                    win 32792  <mss 1460, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0         >  S.  0:0(0)          ack 1                <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.1       <   .  1:1(0)          ack 1     win 10                                                <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0     accept(3, ..., ...) = 4
+
++0         <  P.  1:101(100)      ack 1     win 10                                                <mpcapable v1 flags[flag_h] key[ckey=2, skey] mpcdatalen 100, nop, nop>
++0         >   .  1:1(0)          ack 101              <dss dack8=101  nocs>
+
+// fill the receiver window and get zero window ack
++0     write(4, ..., 2000) = 2000
++0         >  P.  1:1281(1280)    ack 101              <dss dack8=101  dsn8=1    ssn=1 dll=1280    nocs, nop, nop>
++0.1       <   .  101:101(0)      ack 1281  win 0      <dss dack8=1281 nocs>
+
+// zero window probe will trigger; note the MPTCP-level data reinjection used
+// to trigger the probe. It should happens with a delay of 0.5 seconds
++0.3~+0.9  >   .  1280:1280(0)    ack 101              <dss dack8=101                              nocs>
++0.1       <   .  101:101(0)      ack 1281  win 225    <dss dack8=1281                             nocs>
++0         >  P.  1281:1282(1)    ack 101              <dss dack8=101  dsn8=1280 ssn=1281 dll=1    nocs, nop, nop>
+
+// nagle takes action, this one is a little bit delayed or ~0.3 seconds
++0.0~+0.6  >   P.  1282:2002(720) ack 101              <dss dack8=101  dsn8=1281 ssn=1282 dll=720  nocs, nop, nop>
++0    `test $(nstat -zjs | jq '.kernel.MPTcpExtWinProbe') -eq 1`

--- a/gtests/net/packetdrill/packet.c
+++ b/gtests/net/packetdrill/packet.c
@@ -33,6 +33,7 @@
 #include "ip_packet.h"
 #include "logging.h"
 #include "mpls_packet.h"
+#include "tcp_options_iterator.h"
 
 
 /* Info for all types of header we support. */
@@ -267,10 +268,79 @@ struct header_type_info *header_type_info(enum header_t header_type)
 	return &header_types[header_type];
 }
 
+static struct tcp_option *find_dss_option(struct packet *packet, char **error)
+{
+	struct tcp_options_iterator iter;
+	struct tcp_option *opt;
+
+	opt = tcp_options_begin(packet, &iter);
+	while (opt != NULL) {
+		if (opt->kind == TCPOPT_MPTCP &&
+		    opt->data.dss.subtype == DSS_SUBTYPE &&
+		    opt->data.dss.flag_M == 1)
+			return opt;
+
+		opt = tcp_options_next(&iter, error);
+	}
+	return NULL;
+}
+
+static void aggregate_tcp_options(struct packet *packet,
+				  struct packet *first_packet,
+				  char **error)
+{
+	struct tcp_option *d_opt, *s_opt;
+	struct dsn *d_dsn, *s_dsn;
+	u16 delta;
+
+	d_opt = find_dss_option(packet, error);
+	s_opt = find_dss_option(first_packet, error);
+
+	if (!d_opt && !s_opt)
+		return;
+
+	if (!d_opt || !s_opt ||
+	    d_opt->data.dss.flag_m != s_opt->data.dss.flag_m ||
+	    d_opt->data.dss.flag_a != s_opt->data.dss.flag_a ||
+	    d_opt->data.dss.flag_A != s_opt->data.dss.flag_A) {
+		asprintf(error, "MPTCP dss option mismatch");
+		return;
+	}
+
+	if (s_opt->data.dss.flag_a && s_opt->data.dss.flag_A) {
+		d_dsn = (struct dsn*)((u64*)&d_opt->data.dss.dack_dsn + 1);
+		s_dsn = (struct dsn*)((u64*)&s_opt->data.dss.dack_dsn + 1);
+	} else if (s_opt->data.dss.flag_A) {
+		d_dsn = (struct dsn*)((u32*)&d_opt->data.dss.dack_dsn + 1);
+		s_dsn = (struct dsn*)((u32*)&s_opt->data.dss.dack_dsn + 1);
+	} else {
+		d_dsn = &d_opt->data.dss.dsn;
+		s_dsn = &s_opt->data.dss.dsn;
+	}
+
+	if (d_opt->data.dss.flag_m) {
+		delta = be64toh(d_dsn->dsn8) - be64toh(s_dsn->dsn8);
+
+		d_dsn->wo_cs.ssn = s_dsn->wo_cs.ssn;
+		d_dsn->wo_cs.dll = htons(ntohs(d_dsn->wo_cs.dll) + delta);
+		d_dsn->dsn8 = s_dsn->dsn8;
+	} else {
+		u32 *d_ssn = (u32*)d_dsn + 1;
+		u32 *s_ssn = (u32*)s_dsn + 1;
+		u16 *d_dll = (u16*)d_dsn + 2;
+
+		delta = be32toh(d_dsn->dsn4) - be32toh(s_dsn->dsn4);
+
+		*d_ssn = *s_ssn;
+		*d_dll = htons(ntohs(*d_dll) + delta);
+		d_dsn->dsn4 = s_dsn->dsn4;
+	}
+}
+
 /* Aggregate a list of input packets into a single output packet. */
 struct packet *aggregate_packets(const struct packet_list *head,
 				 const struct packet_list *tail,
-				 int payload_size)
+				 int payload_size, char **error)
 {
 	int i;
 	/* Copy the headers from the last source packet. */
@@ -319,6 +389,9 @@ struct packet *aggregate_packets(const struct packet_list *head,
 			assert(first_packet->tcp != NULL);
 			packet->tcp->seq = first_packet->tcp->seq;
 			packet->tcp->cwr = first_packet->tcp->cwr;
+
+			/* MPTCP DSS options needs similar care*/
+			aggregate_tcp_options(packet, first_packet, error);
 		}
 	}
 	packet_finish_encapsulation_headers(packet);

--- a/gtests/net/packetdrill/packet.h
+++ b/gtests/net/packetdrill/packet.h
@@ -164,7 +164,7 @@ extern struct packet *packet_encapsulate(struct packet *outer,
  */
 extern struct packet *aggregate_packets(const struct packet_list *head,
 					const struct packet_list *tail,
-					int payload_size);
+					int payload_size, char **error);
 
 /* Encapsulate a packet and free the original outer and inner packets. */
 static inline struct packet *packet_encapsulate_and_free(struct packet *outer,

--- a/gtests/net/packetdrill/run_packet.c
+++ b/gtests/net/packetdrill/run_packet.c
@@ -2332,7 +2332,8 @@ static int do_outbound_script_packet(
 		}
 		live_packet = aggregate_packets(sniffed_packets_start,
 						sniffed_packets_end,
-						sniffed_payload_len);
+						sniffed_payload_len,
+						error);
 		if (DEBUG_LOGGING) {
 			char *debug = NULL;
 			add_packet_dump(&debug, "live", live_packet,


### PR DESCRIPTION
The tests itself is quite simple, but needs pktdrill performing aggregation correctly even on MPTCP DSS option.

Such thing is implemented by the first patch