### PR TITLE
mptcp: new DATA_FIN retrans tests

### DIFF
--- a/gtests/net/mptcp/dss/dss_fin_rcv_data.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_rcv_data.pkt
@@ -1,0 +1,31 @@
+// Test data_fin retransmission from kernel TCP_ESTABLISHED state
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
++0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
+
++0     bind(3, ..., ...) = 0
++0     listen(3, 1) = 0
++0       <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.1     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0     accept(3, ..., ...) = 4
+
++0       <  P.  1:2(1)  ack 1  win 450    <mpcapable v1 flags[flag_h] key[skey, ckey] mpcdatalen 1, nop, nop>
++0     read(4, ..., 1) = 1
++0       >   .  1:1(0)  ack 2             <dss dack8=2 nocs>
+
+// shutdown
++0     shutdown(4, SHUT_WR) = 0
++0       >   .  1:1(0)        ack 2                <dss dack8=2 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
+
+// ACK the data_fin
++0       <   .  2:1002(1000)  ack 1     win 450    <dss dack8=2 dsn8=2 ssn=2 dll=1001 nocs fin, nop, nop>
++0       >   .  1:1(0)        ack 1002             <dss dack8=1002 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
++0       >  F.  1:1(0)        ack 1002             <dss dack8=1003 nocs>
++0       <  F.  1002:1002(0)  ack 2     win 450    <dss dack8=2 nocs>
+
++0     read(4, ..., 1500) = 1000
+// Here, `ss -Mt` should not report anything.
++0.5   `! ss -Mtn | grep tcp`

--- a/gtests/net/mptcp/dss/dss_fin_rcv_data_no_mpc.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_rcv_data_no_mpc.pkt
@@ -1,0 +1,27 @@
+// Test data_fin retransmission from kernel TCP_ESTABLISHED state
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
++0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
+
++0     bind(3, ..., ...) = 0
++0     listen(3, 1) = 0
++0       <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.1     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0     accept(3, ..., ...) = 4
+
+// shutdown
++0     shutdown(4, SHUT_WR) = 0
++0       >   .  1:1(0)        ack 1                <dss dack4=1    dsn8=1 ssn=0 dll=1    nocs fin, nop, nop>
+
+// ACK the data_fin
++0       <   .  1:1001(1000)  ack 1     win 450    <dss dack8=2    dsn8=1 ssn=1 dll=1001 nocs fin, nop, nop>
++0       >   .  1:1(0)        ack 1001             <dss dack8=1001 dsn8=1 ssn=0 dll=1    nocs fin, nop, nop>
++0       >  F.  1:1(0)        ack 1001             <dss dack8=1002 nocs>
++0       <  F.  1001:1001(0)  ack 2     win 450    <dss dack8=2    nocs>
++0     read(4, ..., 1500) = 1000
+
+// Here, `ss -Mt` will report nothing
++0.5   `! ss -Mtn | grep tcp`

--- a/gtests/net/mptcp/dss/dss_fin_rcv_retrans_fin.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_rcv_retrans_fin.pkt
@@ -1,0 +1,34 @@
+// Test data_fin retransmission from kernel TCP_ESTABLISHED state
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
++0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
+
++0     bind(3, ..., ...) = 0
++0     listen(3, 1) = 0
++0       <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.1     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0     accept(3, ..., ...) = 4
+
+// shutdown initiated by the other peer
++0.1     <   .  1:1(0)  ack 1 win 450     <dss dack4=1 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
++0       >   .  1:1(0)  ack 1             <dss dack4=2 nocs>
+
+// shutdown
++0     close(4) = 0
++0       >   .  1:1(0)  ack 1             <dss dack4=2 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
+
+// wait for retransmissions
++0.2~+0.3 >  .  1:1(0)  ack 1             <dss dack4=2 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
++0.2~+0.3 >  .  1:1(0)  ack 1             <dss dack4=2 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
++0.4~+0.5 >  .  1:1(0)  ack 1             <dss dack4=2 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
+
+// Here, `ss -Mt` will report one "tcp ESTAB" and one "mptcp LAST-ACK"
++0     `ss -Mn | grep -q LAST-ACK`
+
+// ACK the data_fin
++0       <   .  1:1(0)  ack 1  win 450    <dss dack4=2 nocs>
++0       >  F.  1:1(0)  ack 1             <dss dack4=2 nocs>
++0       <  F.  1:1(0)  ack 2  win 450    <dss dack4=2 nocs>

--- a/gtests/net/mptcp/dss/dss_fin_retrans_last_ack.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_retrans_last_ack.pkt
@@ -1,0 +1,26 @@
+// Test data_fin retransmission from kernel TCP_ESTABLISHED state
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
++0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
+
++0     bind(3, ..., ...) = 0
++0     listen(3, 1) = 0
++0       <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.1     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0     accept(3, ..., ...) = 4
+
+// server shutdown
++0     close(4) = 0
++0       >   .  1:1(0)  ack 1             <dss dack4=1 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
++0.1     <   .  1:1(0)  ack 1  win 450    <dss dack4=2 nocs>
+
+// Here, `ss -Mt` will report one "tcp ESTAB" and one "mptcp FIN-WAIT-2"
++0     `ss -Mn | grep -q FIN-WAIT-2`
+
+// data_fin is received with a delay
++0.6     <   .  1:1(0)  ack 1  win 450    <dss dack4=2 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
++0       >  F.  1:1(0)  ack 1             <dss dack4=2 nocs>
++0       <  F.  1:1(0)  ack 2  win 450    <dss dack4=2 nocs>

--- a/gtests/net/mptcp/dss/dss_fin_snding_data.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_snding_data.pkt
@@ -1,0 +1,36 @@
+// Test data_fin retransmission from kernel TCP_ESTABLISHED state
+--tolerance_usecs=100000
+`../common/defaults.sh
+ ethtool -K tun0 gso off tso off
+ ip link set tun0 gso_max_segs 1 # to force dll of 1000
+`
+
++0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
+
++0     bind(3, ..., ...) = 0
++0     listen(3, 1) = 0
++0       <  S   0:0(0)         win 32792  <mss 1028, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.1     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0     accept(3, ..., ...) = 4
+
++0       <  P.  1:2(1)  ack 1  win 450    <mpcapable v1 flags[flag_h] key[skey, ckey] mpcdatalen 1, nop, nop>
++0     read(4, ..., 1) = 1
++0       >   .  1:1(0)  ack 2             <dss dack8=2 nocs>
+
+// shutdown
++0.1   write(4, ..., 10000) = 10000
++0     shutdown(4, SHUT_WR) = 0
++0       >  P.  1:10001(10000)  ack 2               <dss dack8=2     dsn8=1     ssn=1 dll=10000 nocs, nop, nop>
++0       >   .  10001:10001(0)  ack 2               <dss dack8=2     dsn8=10001 ssn=0 dll=1     nocs fin, nop, nop>
+
+// ACK the data_fin
++0       <   .  2:1002(1000)    ack 10001  win 450  <dss dack8=10002 dsn8=2     ssn=2 dll=1001  nocs fin, nop, nop>
++0       >   .  10001:10001(0)  ack 1002            <dss dack8=1002  dsn8=10001 ssn=0 dll=1     nocs fin, nop, nop>
++0       >  F.  10001:10001(0)  ack 1002            <dss dack8=1003  nocs>
++0       <  F.  1002:1002(0)    ack 10002  win 450  <dss dack8=10002 nocs>
+
++0     read(4, ..., 1500) = 1000
+// Here, `ss -Mt` should not report anything.
++0.5   `! ss -Mtn | grep tcp`

--- a/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_no_mpc_close_data.pkt
+++ b/gtests/net/mptcp/mp_capable/v1_connect_tcpfallback_no_mpc_close_data.pkt
@@ -1,0 +1,30 @@
+// connect() function, connection initiated by the kernel
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
+0.0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0    getsockopt(3, SOL_TCP, TCP_IS_MPTCP, [1], [4]) = 0
++0.0    fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
++0.0    fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+
+// Establish connection and verify that there was no error.
+
++0.0    connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
++0.0      >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++0.1      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100>
++0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700>
+
++0.200  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.200  fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
+
+// Check for fallback
++0.0    getsockopt(3, SOL_TCP, TCP_IS_MPTCP, [0], [4]) = 0
+
+// ensure that traffic plane is functional and does not use DSS
++0.0    shutdown(3, SHUT_WR) = 0
++0.0      >  F.  1:1(0)         ack 1              <nop, nop, TS val 100 ecr 700>
++0.0      <  F.  1:1011(1010)   ack 2     win 257  <nop, nop, TS val 700 ecr 100>
++0.0      >   .  2:2(0)         ack 1012           <nop, nop, TS val 100 ecr 700>
++0.0    read(3, ..., 1500) = 1010
++0.0    `! ss -Mtn | grep FIN_WAIT_2`


### PR DESCRIPTION
The MPTCP CI recently caught an issue with the mptcp_connect.sh test, where one subtest timeout.

When this happens, 'ss -Mt' reports:

 - listener:
   - tcp   ESTAB
   - mptcp LAST-ACK

 - connector:
   - tcp   ESTAB
   - mptcp FIN-WAIT-2

As spotted by Paolo, all bytes have been exchanged, the last data packet has been received 60 seconds ago. So it looks like one data-fin didn't get retransmitted.

In this case, both sides have the connection closed by the userspace: data-fin have been sent to be in such MPTCP states. The listener sent a data-fin, and is waiting for an ACK. The connector side is waiting for a data-fin.

That's what the two new tests are checking:

 - Is the data-fin retransmitted as expected?

 - Is the data-fin ACK retransmitted when received with a delay?

These tests pass with the current MPTCP tree.

Link: https://github.com/multipath-tcp/mptcp_net-next/actions/runs/19047087376