### PR TITLE
mptcp: data with data-fin but not MPC 4th ACK

### DIFF
--- a/gtests/net/mptcp/dss/dss_fin_data_no_mpc_fallback.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_data_no_mpc_fallback.pkt
@@ -1,0 +1,27 @@
+// Test data_fin retransmission from kernel TCP_ESTABLISHED state
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
++0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
+
++0     bind(3, ..., ...) = 0
++0     listen(3, 1) = 0
++0       <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.1     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0     accept(3, ..., ...) = 4
+
+// shutdown
++0     shutdown(4, SHUT_WR) = 0
++0       >   .  1:1(0)        ack 1                <dss dack4=1 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
+
+// ACK the data_fin
++0       <   .  1:1001(1000)  ack 1     win 450    <dss dack8=2 dsn8=1 ssn=0 dll=1001 nocs fin, nop, nop>
++0       >  F.  1:1(0)        ack 1001
++0       <  F.  1001:1001(0)  ack 2     win 450
+
+// Is it normal to ACK the 1000 bytes, but not being able to read them?
++0     read(4, ..., 1500) = -1  ENOTCONN (Transport endpoint is not connected)
+// Here, `ss -Mt` will report nothing
++0.5   `! ss -Mtn | grep tcp`


### PR DESCRIPTION
This causes a fallback.

This is currently a draft, because there are two points of attention:

- The last read() doesn't work: what about the 1000B that got received and ACKed at TCP level?

- Also, this cause a WARN_ON_ONCE(), see: https://github.com/multipath-tcp/mptcp_net-next/issues/598