### PR TITLE
mptcp: dss: retrans data-fin once more

### DIFF
--- a/gtests/net/mptcp/dss/dss_fin_rcv_retrans_fin.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_rcv_retrans_fin.pkt
@@ -28,6 +28,9 @@
 // Here, `ss -Mt` will report one "tcp ESTAB" and one "mptcp LAST-ACK"
 +0     `ss -Mn | grep -q LAST-ACK`
 
+// One more with more tolerance: the prev cmd can be slow and cause retransmit
++0~+1.6  >   .  1:1(0)  ack 1             <dss dack4=2 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
+
 // ACK the data_fin
 +0       <   .  1:1(0)  ack 1  win 450    <dss dack4=2 nocs>
 +0       >  F.  1:1(0)  ack 1             <dss dack4=2 nocs>

--- a/gtests/net/mptcp/dss/dss_fin_retrans_last_ack.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_retrans_last_ack.pkt
@@ -15,7 +15,7 @@
 // server shutdown
 +0     close(4) = 0
 +0       >   .  1:1(0)  ack 1             <dss dack4=1 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
-+0.1     <   .  1:1(0)  ack 1  win 450    <dss dack4=2 nocs>
++0.05    <   .  1:1(0)  ack 1  win 450    <dss dack4=2 nocs>
 
 // Here, `ss -Mt` will report one "tcp ESTAB" and one "mptcp FIN-WAIT-2"
 +0     `ss -Mn | grep -q FIN-WAIT-2`


### PR DESCRIPTION
On slow environments, the test can fail because the DATA_FIN ACK can be injected with a too long delay after the 'ss' command.

To avoid that, an extra retransmit is expected with a greater tolerance.

While at it, also reduce the delay to inject the DATA_FIN ACK in `dss_fin_retrans_last_ack` to avoid a retransmission of the DATA_FIN.

Cc: @pabeni (as I mentioned these issues in an email to you on the MPTCP ML)