### PR TITLE
mptcp: dss: no time expectation after ss cmd

### DIFF
--- a/gtests/net/mptcp/dss/dss_fin_rcv_retrans_fin.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_rcv_retrans_fin.pkt
@@ -28,8 +28,8 @@
 // Here, `ss -Mt` will report one "tcp ESTAB" and one "mptcp LAST-ACK"
 +0     `ss -Mn | grep -q LAST-ACK`
 
-// One more with more tolerance: the prev cmd can be slow and cause retransmit
-+0~+1.6  >   .  1:1(0)  ack 1             <dss dack4=2 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
+// One more with no time: the prev cmd can be slow and cause retransmit
+*        >   .  1:1(0)  ack 1             <dss dack4=2 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
 
 // ACK the data_fin
 +0       <   .  1:1(0)  ack 1  win 450    <dss dack4=2 nocs>


### PR DESCRIPTION
On slow environments, the test can fail because the DATA_FIN ACK can be injected with a too long delay after the 'ss' command.

To avoid that, an extra retransmit has been expected with a greater tolerance. Still, the test has been seen failing with:

    dss_fin_rcv_retrans_fin.pkt:32: error handling packet: timing error: expected outbound packet in relative time range +0.000000~+1.600000 sec but happened at -2.492486 sec

Remove the time expectation for this retransmission.