### PR TITLE
mptcp: increase tolerance & RTT and remove delay

### DIFF
--- a/gtests/net/mptcp/add_addr/add_addr4_client.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr4_client.pkt
@@ -11,7 +11,7 @@
 
 +0.0   connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
 +0.0      >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.1      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.4      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 +0.200  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0

--- a/gtests/net/mptcp/add_addr/add_addr4_server.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr4_server.pkt
@@ -11,9 +11,9 @@
 
 +0     bind(3, ..., ...) = 0
 +0     listen(3, 1) = 0
-+0       <  S   0:0(0)         win 32792  <mss 1460, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0.1     <  S   0:0(0)         win 32792  <mss 1460, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.01    <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.4     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
 
 // ADD_ADDR is sent directly (>= 5.12), not after first data (< 5.12)

--- a/gtests/net/mptcp/add_addr/add_addr6_client.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr6_client.pkt
@@ -11,7 +11,7 @@
 
 +0.0   connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
 +0.0      >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.1      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.4      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 +0.200  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0

--- a/gtests/net/mptcp/add_addr/add_addr6_server.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr6_server.pkt
@@ -11,9 +11,9 @@
 
 +0     bind(3, ..., ...) = 0
 +0     listen(3, 1) = 0
-+0       <  S   0:0(0)         win 32792  <mss 1460, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0.1     <  S   0:0(0)         win 32792  <mss 1460, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.01    <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.4     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
 
 // ADD_ADDR is sent directly (>= 5.12), not after first data (< 5.12)

--- a/gtests/net/mptcp/add_addr/add_addr_echo_new_sf.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr_echo_new_sf.pkt
@@ -10,7 +10,7 @@
 
 +0.0  connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
 +0.0    >  addr[caddr0] > addr[saddr0]  S   0:0(0)                        <mss 1460, sackOK, TS val 4074410674 ecr 0,          nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.1    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.4    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0    >                                .  1:1(0)      ack 1             <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 +0.2  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
@@ -24,7 +24,7 @@
 
 
 +0.0    >  addr[caddr1] > addr[saddr0]  S   0:0(0)                        <mss 1460, sackOK, TS val 448955294 ecr 0,         nop, wscale 8, mp_join_syn     address_id=1 token=sha256_32(skey)>
-+0.1    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack address_id=0 sender_hmac=auto>
++0.4    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack address_id=0 sender_hmac=auto>
 +0.0    >                                .  1:1(0)      ack 1             <nop, nop,         TS val 448955294 ecr 448955294,                mp_join_ack                  sender_hmac=auto>
 +0.1    <                                .  1:1(0)      ack 1  win 256    <nop, nop,         TS val 448955294 ecr 448955294,                add_address address_id=1 addr[caddr1] addr_echo>
 

--- a/gtests/net/mptcp/dss/dss_fin_rcv_data.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_rcv_data.pkt
@@ -7,9 +7,9 @@
 
 +0     bind(3, ..., ...) = 0
 +0     listen(3, 1) = 0
-+0       <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0.1     <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.1     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.4     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
 
 +0       <  P.  1:2(1)  ack 1  win 450    <mpcapable v1 flags[flag_h] key[skey, ckey] mpcdatalen 1, nop, nop>

--- a/gtests/net/mptcp/dss/dss_fin_rcv_data_no_mpc.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_rcv_data_no_mpc.pkt
@@ -7,9 +7,9 @@
 
 +0     bind(3, ..., ...) = 0
 +0     listen(3, 1) = 0
-+0       <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0.1     <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.1     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.4     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
 
 // shutdown

--- a/gtests/net/mptcp/dss/dss_fin_rcv_retrans_fin.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_rcv_retrans_fin.pkt
@@ -7,9 +7,9 @@
 
 +0     bind(3, ..., ...) = 0
 +0     listen(3, 1) = 0
-+0       <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0.1     <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.1     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.4     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
 
 // shutdown initiated by the other peer

--- a/gtests/net/mptcp/dss/dss_fin_rcv_retrans_fin.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_rcv_retrans_fin.pkt
@@ -1,5 +1,5 @@
 // Test data_fin retransmission from kernel TCP_ESTABLISHED state
---tolerance_usecs=100000
+--tolerance_usecs=200000
 `../common/defaults.sh`
 
 +0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3

--- a/gtests/net/mptcp/dss/dss_fin_retrans_close_wait.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_retrans_close_wait.pkt
@@ -1,5 +1,5 @@
 // Test data_fin retransmission from kernel TCP_CLOSE_WAIT state
---tolerance_usecs=100000
+--tolerance_usecs=200000
 `../common/defaults.sh`
 
 +0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3

--- a/gtests/net/mptcp/dss/dss_fin_retrans_close_wait.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_retrans_close_wait.pkt
@@ -7,9 +7,9 @@
 
 +0     bind(3, ..., ...) = 0
 +0     listen(3, 1) = 0
-+0       <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0.1     <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.1     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.4     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
 
 // the client shutdown its side

--- a/gtests/net/mptcp/dss/dss_fin_retrans_established.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_retrans_established.pkt
@@ -7,9 +7,9 @@
 
 +0     bind(3, ..., ...) = 0
 +0     listen(3, 1) = 0
-+0       <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0.1     <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.1     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.4     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
 
 // server shutdown

--- a/gtests/net/mptcp/dss/dss_fin_retrans_established.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_retrans_established.pkt
@@ -1,5 +1,5 @@
 // Test data_fin retransmission from kernel TCP_ESTABLISHED state
---tolerance_usecs=100000
+--tolerance_usecs=200000
 `../common/defaults.sh`
 
 +0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3

--- a/gtests/net/mptcp/dss/dss_fin_retrans_last_ack.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_retrans_last_ack.pkt
@@ -7,9 +7,9 @@
 
 +0     bind(3, ..., ...) = 0
 +0     listen(3, 1) = 0
-+0       <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0.1     <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.1     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.4     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
 
 // server shutdown

--- a/gtests/net/mptcp/dss/dss_fin_server.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_server.pkt
@@ -7,9 +7,9 @@
 
 +0     bind(3, ..., ...) = 0
 +0     listen(3, 1) = 0
-+0       <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0.1     <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey] >
-+0.1     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey] >
++0.4     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey] >
 +0     accept(3, ..., ...) = 4
 
 // the client shutdown its side

--- a/gtests/net/mptcp/dss/dss_fin_snding_data.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_snding_data.pkt
@@ -10,9 +10,9 @@
 
 +0     bind(3, ..., ...) = 0
 +0     listen(3, 1) = 0
-+0       <  S   0:0(0)         win 32792  <mss 1028, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0.1     <  S   0:0(0)         win 32792  <mss 1028, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.1     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.4     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
 
 +0       <  P.  1:2(1)  ack 1  win 450    <mpcapable v1 flags[flag_h] key[skey, ckey] mpcdatalen 1, nop, nop>

--- a/gtests/net/mptcp/dss/dss_ssn_specified_client.pkt
+++ b/gtests/net/mptcp/dss/dss_ssn_specified_client.pkt
@@ -11,7 +11,7 @@
 
 +0.0    connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
 +0.0      >  S   0:0(0)                             <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.1      <  S.  0:0(0)        ack 1     win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.4      <  S.  0:0(0)        ack 1     win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0      >   .  1:1(0)        ack 1                <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 +0.200  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0

--- a/gtests/net/mptcp/dss/dss_ssn_specified_server.pkt
+++ b/gtests/net/mptcp/dss/dss_ssn_specified_server.pkt
@@ -7,9 +7,9 @@
 
 +0     bind(3, ..., ...) = 0
 +0     listen(3, 1) = 0
-+0       <  S   0:0(0)                     win 32792  <mss 1460, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0.1     <  S   0:0(0)                     win 32792  <mss 1460, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)           ack 1                <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.1     <   .  1:1(0)           ack 1     win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.4     <   .  1:1(0)           ack 1     win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
 
 // send 2 data segments and ack them

--- a/gtests/net/mptcp/dss/mpc_with_data_server.pkt
+++ b/gtests/net/mptcp/dss/mpc_with_data_server.pkt
@@ -23,7 +23,7 @@
 // send 1 data segments and ack them
 +0     write(4, ..., 1000) = 1000
 +0       >  P.  1:1001(1000)  ack 101              <dss dack8=101  dsn8=1    ssn=1 dll=1000 nocs, nop, nop>
-+0.1     <   .  101:101(0)    ack 1001  win 225    <dss dack8=1001 dsn8=1    ssn=1 dll=100  nocs, nop, nop>
++0       <   .  101:101(0)    ack 1001  win 225    <dss dack8=1001 dsn8=1    ssn=1 dll=100  nocs, nop, nop>
 
 // read 100 bytes from the MPC+data
 +0.01  read(4, ..., 100) = 100

--- a/gtests/net/mptcp/dss/mpc_with_data_server.pkt
+++ b/gtests/net/mptcp/dss/mpc_with_data_server.pkt
@@ -8,9 +8,9 @@
 +0     `nstat -n`
 +0     bind(3, ..., ...) = 0
 +0     listen(3, 1) = 0
-+0       <  S   0:0(0)                  win 32792  <mss 1460, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0.1     <  S   0:0(0)                  win 32792  <mss 1460, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)        ack 1                <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.01    <   .  1:1(0)        ack 1     win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.4     <   .  1:1(0)        ack 1     win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
 
 +0.01    <  P.  1:101(100)    ack 1     win 225                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey] mpcdatalen 100, nop, nop>

--- a/gtests/net/mptcp/dss/mpc_with_data_server_window_close.pkt
+++ b/gtests/net/mptcp/dss/mpc_with_data_server_window_close.pkt
@@ -1,5 +1,5 @@
 // connection initiated by packetdrill
---tolerance_usecs=100000
+--tolerance_usecs=200000
 `../common/defaults.sh`
 
 +0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
@@ -23,7 +23,7 @@
 
 // zero window probe will trigger; note the MPTCP-level data reinjection used
 // to trigger the probe. It should happens with a delay of 0.5 seconds
-+0.3~+0.9  >   .  1280:1280(0)    ack 101              <dss dack8=101                              nocs>
++0.3~+1.0  >   .  1280:1280(0)    ack 101              <dss dack8=101                              nocs>
 +0.1       <   .  101:101(0)      ack 1281  win 225    <dss dack8=1281                             nocs>
 +0         >  P.  1281:1282(1)    ack 101              <dss dack8=101  dsn8=1280 ssn=1281 dll=1    nocs, nop, nop>
 

--- a/gtests/net/mptcp/fastopen/client-MSG_FASTOPEN-no-cookie.pkt
+++ b/gtests/net/mptcp/fastopen/client-MSG_FASTOPEN-no-cookie.pkt
@@ -14,7 +14,7 @@
 // check the rest is OK
 +0.1    write(3, ..., 1000) = 1000
 +0.0      >  P.  501:1501(1000)  ack 1                <nop, nop, TS val 100 ecr 700, mpcapable v1 flags[flag_h] key[ckey, skey] mpcdatalen 1000, nop, nop>
-+0.1      <   .  1:1(0)          ack 1501  win 225                                  <dss dack8=1001 nocs>
++0.0      <   .  1:1(0)          ack 1501  win 225                                  <dss dack8=1001 nocs>
 
 +0.1    close(3) = 0
 +0.0      >   .  1501:1501(0)    ack 1                <nop, nop, TS val 100 ecr 700, dss dack4=1 dsn8=1001 ssn=0 dll=1 nocs fin, nop, nop>

--- a/gtests/net/mptcp/fastopen/client-MSG_FASTOPEN-no-cookie.pkt
+++ b/gtests/net/mptcp/fastopen/client-MSG_FASTOPEN-no-cookie.pkt
@@ -8,7 +8,7 @@
 +0.0    sendto(3, ..., 500, MSG_FASTOPEN, ..., ...) = 500
 
 +0.0      >  S   0:500(500)                           <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.1      <  S.  0:0(0)          ack 501   win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.4      <  S.  0:0(0)          ack 501   win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0      >   .  501:501(0)      ack 1                <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 // check the rest is OK

--- a/gtests/net/mptcp/fastopen/client-MSG_FASTOPEN.pkt
+++ b/gtests/net/mptcp/fastopen/client-MSG_FASTOPEN.pkt
@@ -8,7 +8,7 @@
 +0.0    sendto(3, ..., 500, MSG_FASTOPEN, ..., ...) = -1 EINPROGRESS (Operation now in progress)
 
 +0.0      >  S   0:0(0)                               <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO,          nop, nop, mpcapable v1 flags[flag_h] nokey>
-+0.1      <  S.  0:0(0)          ack 1     win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, FO abcd1234, nop, nop, mpcapable v1 flags[flag_h] key[skey=2]>
++0.4      <  S.  0:0(0)          ack 1     win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, FO abcd1234, nop, nop, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0      >   .  1:1(0)          ack 1                <nop, nop,         TS val 100 ecr 700,                                       mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 +0.01   close(3) = 0

--- a/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_CONNECT-no-cookie.pkt
+++ b/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_CONNECT-no-cookie.pkt
@@ -12,7 +12,7 @@
 +0.0    write(3, ..., 500) = 500
 
 +0.0      >  S   0:500(500)                           <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.1      <  S.  0:0(0)          ack 501   win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.4      <  S.  0:0(0)          ack 501   win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0      >   .  501:501(0)      ack 1                <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 // check the rest is OK
@@ -25,4 +25,4 @@
 +0.0    getsockopt(3, SOL_TCP, TCP_FASTOPEN_CONNECT, [1], [4]) = 0
 
 +0.1    close(3) = 0
-+0.01     >   .  1501:1501(0)    ack 1                <nop, nop, TS val 100 ecr 700, dss dack4=1 dsn8=1001 ssn=0 dll=1 nocs fin, nop, nop>
++0.0      >   .  1501:1501(0)    ack 1                <nop, nop, TS val 100 ecr 700, dss dack4=1 dsn8=1001 ssn=0 dll=1 nocs fin, nop, nop>

--- a/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_CONNECT-no-cookie.pkt
+++ b/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_CONNECT-no-cookie.pkt
@@ -18,7 +18,7 @@
 // check the rest is OK
 +0.1    write(3, ..., 1000) = 1000
 +0.0      >  P.  501:1501(1000)  ack 1                <nop, nop, TS val 100 ecr 700, mpcapable v1 flags[flag_h] key[ckey, skey] mpcdatalen 1000, nop, nop>
-+0.01     <   .  1:1(0)          ack 1501  win 225                                  <dss dack8=1001 nocs>
++0.0      <   .  1:1(0)          ack 1501  win 225                                  <dss dack8=1001 nocs>
 
 // Similar to TCP?
 +0.0    setsockopt(3, SOL_TCP, TCP_FASTOPEN_CONNECT, [1], 4) = -1 (Invalid argument)

--- a/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_CONNECT.pkt
+++ b/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_CONNECT.pkt
@@ -9,7 +9,7 @@
 +0.0    connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
 
 +0.0      >  S   0:0(0)                               <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO,          nop, nop, mpcapable v1 flags[flag_h] nokey>
-+0.1      <  S.  0:0(0)          ack 1     win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, FO abcd1234, nop, nop, mpcapable v1 flags[flag_h] key[skey=2]>
++0.4      <  S.  0:0(0)          ack 1     win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, FO abcd1234, nop, nop, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0      >   .  1:1(0)          ack 1                <nop, nop,         TS val 100 ecr 700,                                       mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 +0.01   close(3) = 0

--- a/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_NO_COOKIE.pkt
+++ b/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_NO_COOKIE.pkt
@@ -14,7 +14,7 @@
 +0.0    write(3, ..., 500) = 500
 
 +0.0      >  S   0:500(500)                           <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.1      <  S.  0:0(0)          ack 501   win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.4      <  S.  0:0(0)          ack 501   win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0      >   .  501:501(0)      ack 1                <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 // check the rest is OK
@@ -27,4 +27,4 @@
 +0.0    getsockopt(3, SOL_TCP, TCP_FASTOPEN_NO_COOKIE, [1], [4]) = 0
 
 +0.1    close(3) = 0
-+0.01     >   .  1501:1501(0)    ack 1                <nop, nop, TS val 100 ecr 700, dss dack4=1 dsn8=1001 ssn=0 dll=1 nocs fin, nop, nop>
++0.0      >   .  1501:1501(0)    ack 1                <nop, nop, TS val 100 ecr 700, dss dack4=1 dsn8=1001 ssn=0 dll=1 nocs fin, nop, nop>

--- a/gtests/net/mptcp/fastopen/fastopen-invalid-buf-ptr.pkt
+++ b/gtests/net/mptcp/fastopen/fastopen-invalid-buf-ptr.pkt
@@ -11,7 +11,7 @@
 +0.0    connect(3, ..., ...) = -1 EINPROGRESS (Operation is now in progress)
 
 +0.0      >  S   0:0(0)                               <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO,          nop, nop, mpcapable v1 flags[flag_h] nokey>
-+0.1      <  S.  0:0(0)          ack 1     win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, FO abcd1234, nop, nop, mpcapable v1 flags[flag_h] key[skey=2]>
++0.4      <  S.  0:0(0)          ack 1     win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, FO abcd1234, nop, nop, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0      >   .  1:1(0)          ack 1                <nop, nop,         TS val 100 ecr 700,                                       mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 +0.01   close(3) = 0

--- a/gtests/net/mptcp/fastopen/server-TCP_FASTOPEN-cookie-data.pkt
+++ b/gtests/net/mptcp/fastopen/server-TCP_FASTOPEN-cookie-data.pkt
@@ -11,9 +11,9 @@
 +0.0    listen(3, 1) = 0
 
 // The Cookie has already been exchanged before, data can already been exchanged
-+0.0      <  S   0:500(500)                win 65535  <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO TFO_COOKIE, nop, nop, mpcapable v1 flags[flag_h] nokey>
++0.1      <  S   0:500(500)                win 65535  <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO TFO_COOKIE, nop, nop, mpcapable v1 flags[flag_h] nokey>
 +0.0      >  S.  0:0(0)          ack 501              <mss 1460, sackOK, TS val 100 ecr 100, nop, wscale 8,                          mpcapable v1 flags[flag_h] key[skey]>
-+0.01     <   .  501:501(0)      ack 1     win 450    <                                                                              mpcapable v1 flags[flag_h] key[ckey, skey]>
++0.4      <   .  501:501(0)      ack 1     win 450    <                                                                              mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 +0.2    accept(3, ..., ...) = 4
 
@@ -26,4 +26,4 @@
 +0.2    read(4, ..., 1000) = 1000
 
 +0.2    close(4) = 0
-+0.01     >   .  1:1(0)          ack 1501                     <nop, nop, TS val 100 ecr 100, dss dack8=1001 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
++0.0      >   .  1:1(0)          ack 1501                     <nop, nop, TS val 100 ecr 100, dss dack8=1001 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>

--- a/gtests/net/mptcp/fastopen/server-TCP_FASTOPEN-cookie-req.pkt
+++ b/gtests/net/mptcp/fastopen/server-TCP_FASTOPEN-cookie-req.pkt
@@ -12,9 +12,9 @@
 +0.0    bind(3, ..., ...) = 0
 +0.0    listen(3, 1) = 0
 
-+0.0      <  S   0:0(0)                win 65535  <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO,            nop, nop, mpcapable v1 flags[flag_h] nokey>
++0.1      <  S   0:0(0)                win 65535  <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO,            nop, nop, mpcapable v1 flags[flag_h] nokey>
 +0.0      >  S.  0:0(0)      ack 1                <mss 1460, nop, nop, sackOK,           nop, wscale 8, FO TFO_COOKIE, nop, nop, mpcapable v1 flags[flag_h] key[skey]>
-+0.1      <   .  1:1(0)      ack 1     win 450    <                                                                              mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.4      <   .  1:1(0)      ack 1     win 450    <                                                                              mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 
 +0.2    accept(3, ..., ...) = 4
 +0.2    close(4) = 0

--- a/gtests/net/mptcp/fastopen/server-TCP_FASTOPEN_NO_COOKIE.pkt
+++ b/gtests/net/mptcp/fastopen/server-TCP_FASTOPEN_NO_COOKIE.pkt
@@ -12,9 +12,9 @@
 +0.0    bind(3, ..., ...) = 0
 +0.0    listen(3, 1) = 0
 
-+0.0      <  S   0:500(500)               win 65535  <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO, nop, nop, mpcapable v1 flags[flag_h] nokey>
++0.1      <  S   0:500(500)               win 65535  <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO, nop, nop, mpcapable v1 flags[flag_h] nokey>
 +0.0      >  S.  0:0(0)          ack 501             <mss 1460, sackOK, TS val 100 ecr 100, nop, wscale 8,               mpcapable v1 flags[flag_h] key[skey]>
-+0.01     <   .  501:501(0)      ack 1    win 450    <nop, nop,         TS val 100 ecr 100,                              mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.4      <   .  501:501(0)      ack 1    win 450    <nop, nop,         TS val 100 ecr 100,                              mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 
 +0.01   accept(3, ..., ...) = 4
 
@@ -25,4 +25,4 @@
 +0.2    read(4, ..., 1500) = 1500
 
 +0.2    close(4) = 0
-+0.01     >   .  1:1(0)          ack 1501            <nop, nop, TS val 100 ecr 700, dss dack8=1001 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
++0.0      >   .  1:1(0)          ack 1501            <nop, nop, TS val 100 ecr 700, dss dack8=1001 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>

--- a/gtests/net/mptcp/fastopen/server-tfo-no-cookie.pkt
+++ b/gtests/net/mptcp/fastopen/server-tfo-no-cookie.pkt
@@ -17,7 +17,7 @@
 
 // check the rest is OK
 +0.0      <  P.  501:1501(1000)  ack 1     win 225   <nop, nop, TS val 100 ecr 100, mpcapable v1 flags[flag_h] key[ckey, skey] mpcdatalen 1000, nop, nop>
-+0.01     >   .  1:1(0)          ack 1501            <nop, nop, TS val 100 ecr 100, dss dack8=1001 nocs>
++0.0      >   .  1:1(0)          ack 1501            <nop, nop, TS val 100 ecr 100, dss dack8=1001 nocs>
 
 +0.2    read(4, ..., 1500) = 1500
 

--- a/gtests/net/mptcp/fastopen/server-tfo-no-cookie.pkt
+++ b/gtests/net/mptcp/fastopen/server-tfo-no-cookie.pkt
@@ -9,9 +9,9 @@
 +0.0    bind(3, ..., ...) = 0
 +0.0    listen(3, 1) = 0
 
-+0.0      <  S   0:500(500)               win 65535  <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO, nop, nop, mpcapable v1 flags[flag_h] nokey>
++0.1      <  S   0:500(500)               win 65535  <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO, nop, nop, mpcapable v1 flags[flag_h] nokey>
 +0.0      >  S.  0:0(0)          ack 501             <mss 1460, sackOK, TS val 100 ecr 100, nop, wscale 8,               mpcapable v1 flags[flag_h] key[skey]>
-+0.01     <   .  501:501(0)      ack 1    win 450    <nop, nop,         TS val 100 ecr 100,                              mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.4      <   .  501:501(0)      ack 1    win 450    <nop, nop,         TS val 100 ecr 100,                              mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 
 +0.01   accept(3, ..., ...) = 4
 
@@ -22,4 +22,4 @@
 +0.2    read(4, ..., 1500) = 1500
 
 +0.2    close(4) = 0
-+0.01     >   .  1:1(0)          ack 1501            <nop, nop, TS val 100 ecr 700, dss dack8=1001 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>
++0.0      >   .  1:1(0)          ack 1501            <nop, nop, TS val 100 ecr 700, dss dack8=1001 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>

--- a/gtests/net/mptcp/mp_join/mp_join_client.pkt
+++ b/gtests/net/mptcp/mp_join/mp_join_client.pkt
@@ -10,7 +10,7 @@
 
 +0.0  connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
 +0.0    >  addr[caddr0] > addr[saddr0]  S   0:0(0)                        <mss 1460, sackOK, TS val 4074410674 ecr 0,          nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.1    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.4    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0    >                                .  1:1(0)      ack 1             <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 +0.2  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
@@ -24,7 +24,7 @@
 
 
 +0.0    >               > addr[saddr1]  S   0:0(0)                        <mss 1460, sackOK, TS val 448955294 ecr 0,         nop, wscale 8, mp_join_syn     address_id=0 token=sha256_32(skey)>
-+0.1    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
++0.4    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
 +0.0    >                                .  1:1(0)      ack 1             <nop, nop,         TS val 448955294 ecr 448955294,                mp_join_ack                  sender_hmac=auto>
 
 +0.0    <                                .  1:1(0)      ack 1  win 256    <nop, nop,         TS val 448955294 ecr 448955294, dss dack8=3   nocs>

--- a/gtests/net/mptcp/mp_join/mp_join_server.pkt
+++ b/gtests/net/mptcp/mp_join/mp_join_server.pkt
@@ -11,9 +11,9 @@
 +0    bind(3, ..., ...) = 0
 +0    listen(3, 1) = 0
 
-+0.0    <  addr[caddr0] > addr[saddr0]  S   0:0(0)         win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 0,          nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++0.1    <  addr[caddr0] > addr[saddr0]  S   0:0(0)         win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 0,          nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
 +0.0    >                               S.  0:0(0)  ack 1             <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.1    <                                .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.4    <                                .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0    accept(3, ..., ...) = 4
 
 +0.0    <                               P.  1:3(2)  ack 1  win 256    <nop, nop,         TS val 4074418292 ecr 4074410674,                mpcapable v1 flags[flag_h] key[skey, ckey] mpcdatalen 2, nop, nop>
@@ -22,7 +22,7 @@
 +0.0    >                                .  1:1(0)  ack 3             <nop, nop,         TS val 4074418293 ecr 4074418292,                dss dack8=3 dll=0 nocs>
 
 // create subflow
-+0.0    <  addr[caddr1] > addr[saddr0]  S   0:0(0)         win 65535  <mss 1460, sackOK, TS val 448955294  ecr 0,          nop, wscale 8, mp_join_syn     address_id=1 token=sha256_32(skey)>
++0.1    <  addr[caddr1] > addr[saddr0]  S   0:0(0)         win 65535  <mss 1460, sackOK, TS val 448955294  ecr 0,          nop, wscale 8, mp_join_syn     address_id=1 token=sha256_32(skey)>
 +0.0    >                               S.  0:0(0)  ack 1             <mss 1460, sackOK, TS val 448955294  ecr 448955294,  nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
 +0.1    <                                .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 448955294  ecr 448955294,                 mp_join_ack                  sender_hmac=auto>
 

--- a/gtests/net/mptcp/mp_prio/mp_prio_server.pkt
+++ b/gtests/net/mptcp/mp_prio/mp_prio_server.pkt
@@ -10,9 +10,9 @@
 +0    bind(3, ..., ...) = 0
 +0    listen(3, 1) = 0
 
-+0.0    <  addr[caddr0] > addr[saddr0]  S   0:0(0)               win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 0,          nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++0.1    <  addr[caddr0] > addr[saddr0]  S   0:0(0)               win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 0,          nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
 +0.0    >                               S.  0:0(0)        ack 1             <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.1    <                                .  1:1(0)        ack 1  win 256    <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.4    <                                .  1:1(0)        ack 1  win 256    <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0    accept(3, ..., ...) = 4
 
 +0.2    <                               P.  1:3(2)        ack 1  win 256    <nop, nop, TS val 4074418292 ecr 4074410674,                        mpcapable v1 flags[flag_h] key[skey, ckey] mpcdatalen 2, nop, nop>
@@ -27,9 +27,9 @@
 +0.0  read(4, ..., 2) = 2
 
 // create subflow
-+0.0    <  addr[caddr1] > addr[saddr0]  S   0:0(0)               win 65535  <mss 1460, sackOK, TS val 448955294 ecr 0,         nop, wscale 8, mp_join_syn     backup=1 address_id=1 token=sha256_32(skey)>
++0.1    <  addr[caddr1] > addr[saddr0]  S   0:0(0)               win 65535  <mss 1460, sackOK, TS val 448955294 ecr 0,         nop, wscale 8, mp_join_syn     backup=1 address_id=1 token=sha256_32(skey)>
 +0.0    >                               S.  0:0(0)        ack 1             <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack          address_id=0 sender_hmac=auto>
-+0.1    <                                .  1:1(0)        ack 1  win 256    <nop, nop, TS val 448955294 ecr 448955294,                        mp_join_ack sender_hmac=auto>
++0.4    <                                .  1:1(0)        ack 1  win 256    <nop, nop, TS val 448955294 ecr 448955294,                        mp_join_ack sender_hmac=auto>
 +0.0    >                                .  1:1(0)        ack 1             <nop, nop, TS val 448955294 ecr 448955294,                        dss dack4=5 nocs>
 
 // more inbound data and MP_PRIO to flip backup -> active

--- a/gtests/net/mptcp/sockopts/sockopt_set_ip_tos_invalid_v4.pkt
+++ b/gtests/net/mptcp/sockopts/sockopt_set_ip_tos_invalid_v4.pkt
@@ -11,7 +11,7 @@
 +0.0  connect(7, ..., ...) = -1  EINPROGRESS (Operation now in progress)
 
 +0.0  >  [tos 0x04]  addr[caddr0] > addr[saddr0]  S   0:0(0)                    <mss 1460, sackOK, TS val 4074410674 ecr 0,          nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.1  <                                           S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.4  <                                           S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0  >  [tos 0x04]                                .  1:1(0)  ack 1             <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 +0.0  fcntl(7, F_SETFL, O_RDWR) = 0   // set back to blocking
@@ -26,7 +26,7 @@
 +0.0  setsockopt(7, SOL_IP, IP_TOS, [7], 4) = 0
 
 +0.0  >  [tos 0x04]               > addr[saddr1]  S   0:0(0)                    <mss 1460, sackOK, TS val 448955294 ecr 0,         nop, wscale 8, mp_join_syn     address_id=0 token=sha256_32(skey)>
-+0.1  <                                           S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
++0.4  <                                           S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
 +0.0  >  [tos 0x04]                                .  1:1(0)  ack 1             <nop, nop,         TS val 448955294 ecr 448955294,                mp_join_ack                  sender_hmac=auto>
 +0.0  <                                            .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 448955294 ecr 448955294,   dss dack8=3   nocs>
 

--- a/gtests/net/mptcp/sockopts/sockopt_set_ip_tos_valid_v4.pkt
+++ b/gtests/net/mptcp/sockopts/sockopt_set_ip_tos_valid_v4.pkt
@@ -11,7 +11,7 @@
 +0.0  connect(7, ..., ...) = -1  EINPROGRESS (Operation now in progress)
 
 +0.0  >  [tos 0x04]  addr[caddr0] > addr[saddr0]  S   0:0(0)                    <mss 1460, sackOK, TS val 4074410674 ecr 0,          nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.1  <                                           S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.4  <                                           S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0  >  [tos 0x04]                                .  1:1(0)  ack 1             <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 +0.0  fcntl(7, F_SETFL, O_RDWR) = 0   // set back to blocking
@@ -26,7 +26,7 @@
 +0.0  setsockopt(7, SOL_IP, IP_TOS, [7], 4) = 0
 
 +0.0  >  [tos 0x04]               > addr[saddr1]  S   0:0(0)                    <mss 1460, sackOK, TS val 448955294 ecr 0,         nop, wscale 8, mp_join_syn     address_id=0 token=sha256_32(skey)>
-+0.1  <                                           S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
++0.4  <                                           S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
 +0.0  >  [tos 0x04]                                .  1:1(0)  ack 1             <nop, nop,         TS val 448955294 ecr 448955294,                mp_join_ack                  sender_hmac=auto>
 +0.0  <                                            .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 448955294 ecr 448955294,   dss dack8=3   nocs>
 

--- a/gtests/net/mptcp/syscalls/connect_close.pkt
+++ b/gtests/net/mptcp/syscalls/connect_close.pkt
@@ -11,7 +11,7 @@
 
 +0.0    connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
 +0.0      >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.1      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.4      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 // client shutdown before any incoming DSS

--- a/gtests/net/mptcp/syscalls/connect_close_ack_ooo.pkt
+++ b/gtests/net/mptcp/syscalls/connect_close_ack_ooo.pkt
@@ -11,7 +11,7 @@
 
 +0.0    connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
 +0.0      >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.1      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.4      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 // client shutdown before any incoming DSS, DATA_FIN is acked by an OoO packet

--- a/gtests/net/mptcp/syscalls/connect_close_full.pkt
+++ b/gtests/net/mptcp/syscalls/connect_close_full.pkt
@@ -11,7 +11,7 @@
 
 +0.0    connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
 +0.0      >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.1      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.4      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 // client shutdown before any incoming DSS


### PR DESCRIPTION
Here are various small modifications hopefully to reduce false positives:
- increase the tolerance of some tests with retransmissions
- remove delay to inject the last ACK before a DATA_FIN to avoid spurious retransmissions
- increase RTT for tests dealing with DATA_FIN to avoid spurious retransmissions

That looks better on my side after that in both normal and debug modes.