### PR TITLE
mptcp: DATA_FIN: lower RTT

### DIFF
--- a/gtests/net/mptcp/add_addr/add_addr4_client.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr4_client.pkt
@@ -11,7 +11,7 @@
 
 +0.0   connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
 +0.0      >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.4      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.2      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 +0.200  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0

--- a/gtests/net/mptcp/add_addr/add_addr4_server.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr4_server.pkt
@@ -13,7 +13,7 @@
 +0     listen(3, 1) = 0
 +0.1     <  S   0:0(0)         win 32792  <mss 1460, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.4     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.2     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
 
 // ADD_ADDR is sent directly (>= 5.12), not after first data (< 5.12)

--- a/gtests/net/mptcp/add_addr/add_addr6_client.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr6_client.pkt
@@ -11,7 +11,7 @@
 
 +0.0   connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
 +0.0      >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.4      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.2      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 +0.200  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0

--- a/gtests/net/mptcp/add_addr/add_addr6_server.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr6_server.pkt
@@ -13,7 +13,7 @@
 +0     listen(3, 1) = 0
 +0.1     <  S   0:0(0)         win 32792  <mss 1460, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.4     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.2     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
 
 // ADD_ADDR is sent directly (>= 5.12), not after first data (< 5.12)

--- a/gtests/net/mptcp/add_addr/add_addr_echo_new_sf.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr_echo_new_sf.pkt
@@ -10,7 +10,7 @@
 
 +0.0  connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
 +0.0    >  addr[caddr0] > addr[saddr0]  S   0:0(0)                        <mss 1460, sackOK, TS val 4074410674 ecr 0,          nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.4    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.2    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0    >                                .  1:1(0)      ack 1             <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 +0.2  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
@@ -24,7 +24,7 @@
 
 
 +0.0    >  addr[caddr1] > addr[saddr0]  S   0:0(0)                        <mss 1460, sackOK, TS val 448955294 ecr 0,         nop, wscale 8, mp_join_syn     address_id=1 token=sha256_32(skey)>
-+0.4    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack address_id=0 sender_hmac=auto>
++0.2    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack address_id=0 sender_hmac=auto>
 +0.0    >                                .  1:1(0)      ack 1             <nop, nop,         TS val 448955294 ecr 448955294,                mp_join_ack                  sender_hmac=auto>
 +0.1    <                                .  1:1(0)      ack 1  win 256    <nop, nop,         TS val 448955294 ecr 448955294,                add_address address_id=1 addr[caddr1] addr_echo>
 

--- a/gtests/net/mptcp/dss/dss_fin_rcv_data.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_rcv_data.pkt
@@ -9,7 +9,7 @@
 +0     listen(3, 1) = 0
 +0.1     <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.4     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.2     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
 
 +0       <  P.  1:2(1)  ack 1  win 450    <mpcapable v1 flags[flag_h] key[skey, ckey] mpcdatalen 1, nop, nop>

--- a/gtests/net/mptcp/dss/dss_fin_rcv_data_no_mpc.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_rcv_data_no_mpc.pkt
@@ -9,7 +9,7 @@
 +0     listen(3, 1) = 0
 +0.1     <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.4     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.2     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
 
 // shutdown

--- a/gtests/net/mptcp/dss/dss_fin_rcv_retrans_fin.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_rcv_retrans_fin.pkt
@@ -9,7 +9,7 @@
 +0     listen(3, 1) = 0
 +0.1     <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.4     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.2     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
 
 // shutdown initiated by the other peer

--- a/gtests/net/mptcp/dss/dss_fin_retrans_close_wait.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_retrans_close_wait.pkt
@@ -9,7 +9,7 @@
 +0     listen(3, 1) = 0
 +0.1     <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.4     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.2     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
 
 // the client shutdown its side

--- a/gtests/net/mptcp/dss/dss_fin_retrans_established.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_retrans_established.pkt
@@ -9,7 +9,7 @@
 +0     listen(3, 1) = 0
 +0.1     <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.4     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.2     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
 
 // server shutdown

--- a/gtests/net/mptcp/dss/dss_fin_retrans_last_ack.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_retrans_last_ack.pkt
@@ -9,7 +9,7 @@
 +0     listen(3, 1) = 0
 +0.1     <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.4     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.2     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
 
 // server shutdown

--- a/gtests/net/mptcp/dss/dss_fin_server.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_server.pkt
@@ -9,7 +9,7 @@
 +0     listen(3, 1) = 0
 +0.1     <  S   0:0(0)         win 32792  <mss 1000, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey] >
-+0.4     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey] >
++0.2     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey] >
 +0     accept(3, ..., ...) = 4
 
 // the client shutdown its side

--- a/gtests/net/mptcp/dss/dss_fin_snding_data.pkt
+++ b/gtests/net/mptcp/dss/dss_fin_snding_data.pkt
@@ -12,7 +12,7 @@
 +0     listen(3, 1) = 0
 +0.1     <  S   0:0(0)         win 32792  <mss 1028, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.4     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.2     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
 
 +0       <  P.  1:2(1)  ack 1  win 450    <mpcapable v1 flags[flag_h] key[skey, ckey] mpcdatalen 1, nop, nop>

--- a/gtests/net/mptcp/dss/dss_ssn_specified_client.pkt
+++ b/gtests/net/mptcp/dss/dss_ssn_specified_client.pkt
@@ -11,7 +11,7 @@
 
 +0.0    connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
 +0.0      >  S   0:0(0)                             <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.4      <  S.  0:0(0)        ack 1     win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.2      <  S.  0:0(0)        ack 1     win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0      >   .  1:1(0)        ack 1                <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 +0.200  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0

--- a/gtests/net/mptcp/dss/dss_ssn_specified_server.pkt
+++ b/gtests/net/mptcp/dss/dss_ssn_specified_server.pkt
@@ -9,7 +9,7 @@
 +0     listen(3, 1) = 0
 +0.1     <  S   0:0(0)                     win 32792  <mss 1460, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)           ack 1                <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.4     <   .  1:1(0)           ack 1     win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.2     <   .  1:1(0)           ack 1     win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
 
 // send 2 data segments and ack them

--- a/gtests/net/mptcp/dss/mpc_with_data_server.pkt
+++ b/gtests/net/mptcp/dss/mpc_with_data_server.pkt
@@ -10,7 +10,7 @@
 +0     listen(3, 1) = 0
 +0.1     <  S   0:0(0)                  win 32792  <mss 1460, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
 +0       >  S.  0:0(0)        ack 1                <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.4     <   .  1:1(0)        ack 1     win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.2     <   .  1:1(0)        ack 1     win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0     accept(3, ..., ...) = 4
 
 +0.01    <  P.  1:101(100)    ack 1     win 225                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey] mpcdatalen 100, nop, nop>

--- a/gtests/net/mptcp/fastopen/client-MSG_FASTOPEN-no-cookie.pkt
+++ b/gtests/net/mptcp/fastopen/client-MSG_FASTOPEN-no-cookie.pkt
@@ -8,7 +8,7 @@
 +0.0    sendto(3, ..., 500, MSG_FASTOPEN, ..., ...) = 500
 
 +0.0      >  S   0:500(500)                           <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.4      <  S.  0:0(0)          ack 501   win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.2      <  S.  0:0(0)          ack 501   win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0      >   .  501:501(0)      ack 1                <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 // check the rest is OK

--- a/gtests/net/mptcp/fastopen/client-MSG_FASTOPEN.pkt
+++ b/gtests/net/mptcp/fastopen/client-MSG_FASTOPEN.pkt
@@ -8,7 +8,7 @@
 +0.0    sendto(3, ..., 500, MSG_FASTOPEN, ..., ...) = -1 EINPROGRESS (Operation now in progress)
 
 +0.0      >  S   0:0(0)                               <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO,          nop, nop, mpcapable v1 flags[flag_h] nokey>
-+0.4      <  S.  0:0(0)          ack 1     win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, FO abcd1234, nop, nop, mpcapable v1 flags[flag_h] key[skey=2]>
++0.2      <  S.  0:0(0)          ack 1     win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, FO abcd1234, nop, nop, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0      >   .  1:1(0)          ack 1                <nop, nop,         TS val 100 ecr 700,                                       mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 +0.01   close(3) = 0

--- a/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_CONNECT-no-cookie.pkt
+++ b/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_CONNECT-no-cookie.pkt
@@ -12,7 +12,7 @@
 +0.0    write(3, ..., 500) = 500
 
 +0.0      >  S   0:500(500)                           <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.4      <  S.  0:0(0)          ack 501   win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.2      <  S.  0:0(0)          ack 501   win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0      >   .  501:501(0)      ack 1                <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 // check the rest is OK

--- a/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_CONNECT.pkt
+++ b/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_CONNECT.pkt
@@ -9,7 +9,7 @@
 +0.0    connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
 
 +0.0      >  S   0:0(0)                               <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO,          nop, nop, mpcapable v1 flags[flag_h] nokey>
-+0.4      <  S.  0:0(0)          ack 1     win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, FO abcd1234, nop, nop, mpcapable v1 flags[flag_h] key[skey=2]>
++0.2      <  S.  0:0(0)          ack 1     win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, FO abcd1234, nop, nop, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0      >   .  1:1(0)          ack 1                <nop, nop,         TS val 100 ecr 700,                                       mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 +0.01   close(3) = 0

--- a/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_NO_COOKIE.pkt
+++ b/gtests/net/mptcp/fastopen/client-TCP_FASTOPEN_NO_COOKIE.pkt
@@ -14,7 +14,7 @@
 +0.0    write(3, ..., 500) = 500
 
 +0.0      >  S   0:500(500)                           <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.4      <  S.  0:0(0)          ack 501   win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.2      <  S.  0:0(0)          ack 501   win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0      >   .  501:501(0)      ack 1                <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 // check the rest is OK

--- a/gtests/net/mptcp/fastopen/fastopen-invalid-buf-ptr.pkt
+++ b/gtests/net/mptcp/fastopen/fastopen-invalid-buf-ptr.pkt
@@ -11,7 +11,7 @@
 +0.0    connect(3, ..., ...) = -1 EINPROGRESS (Operation is now in progress)
 
 +0.0      >  S   0:0(0)                               <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO,          nop, nop, mpcapable v1 flags[flag_h] nokey>
-+0.4      <  S.  0:0(0)          ack 1     win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, FO abcd1234, nop, nop, mpcapable v1 flags[flag_h] key[skey=2]>
++0.2      <  S.  0:0(0)          ack 1     win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, FO abcd1234, nop, nop, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0      >   .  1:1(0)          ack 1                <nop, nop,         TS val 100 ecr 700,                                       mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 +0.01   close(3) = 0

--- a/gtests/net/mptcp/fastopen/server-TCP_FASTOPEN-cookie-data.pkt
+++ b/gtests/net/mptcp/fastopen/server-TCP_FASTOPEN-cookie-data.pkt
@@ -13,7 +13,7 @@
 // The Cookie has already been exchanged before, data can already been exchanged
 +0.1      <  S   0:500(500)                win 65535  <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO TFO_COOKIE, nop, nop, mpcapable v1 flags[flag_h] nokey>
 +0.0      >  S.  0:0(0)          ack 501              <mss 1460, sackOK, TS val 100 ecr 100, nop, wscale 8,                          mpcapable v1 flags[flag_h] key[skey]>
-+0.4      <   .  501:501(0)      ack 1     win 450    <                                                                              mpcapable v1 flags[flag_h] key[ckey, skey]>
++0.2      <   .  501:501(0)      ack 1     win 450    <                                                                              mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 +0.2    accept(3, ..., ...) = 4
 

--- a/gtests/net/mptcp/fastopen/server-TCP_FASTOPEN-cookie-req.pkt
+++ b/gtests/net/mptcp/fastopen/server-TCP_FASTOPEN-cookie-req.pkt
@@ -14,7 +14,7 @@
 
 +0.1      <  S   0:0(0)                win 65535  <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO,            nop, nop, mpcapable v1 flags[flag_h] nokey>
 +0.0      >  S.  0:0(0)      ack 1                <mss 1460, nop, nop, sackOK,           nop, wscale 8, FO TFO_COOKIE, nop, nop, mpcapable v1 flags[flag_h] key[skey]>
-+0.4      <   .  1:1(0)      ack 1     win 450    <                                                                              mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.2      <   .  1:1(0)      ack 1     win 450    <                                                                              mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 
 +0.2    accept(3, ..., ...) = 4
 +0.2    close(4) = 0

--- a/gtests/net/mptcp/fastopen/server-TCP_FASTOPEN_NO_COOKIE.pkt
+++ b/gtests/net/mptcp/fastopen/server-TCP_FASTOPEN_NO_COOKIE.pkt
@@ -14,7 +14,7 @@
 
 +0.1      <  S   0:500(500)               win 65535  <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO, nop, nop, mpcapable v1 flags[flag_h] nokey>
 +0.0      >  S.  0:0(0)          ack 501             <mss 1460, sackOK, TS val 100 ecr 100, nop, wscale 8,               mpcapable v1 flags[flag_h] key[skey]>
-+0.4      <   .  501:501(0)      ack 1    win 450    <nop, nop,         TS val 100 ecr 100,                              mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.2      <   .  501:501(0)      ack 1    win 450    <nop, nop,         TS val 100 ecr 100,                              mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 
 +0.01   accept(3, ..., ...) = 4
 

--- a/gtests/net/mptcp/fastopen/server-tfo-no-cookie.pkt
+++ b/gtests/net/mptcp/fastopen/server-tfo-no-cookie.pkt
@@ -11,7 +11,7 @@
 
 +0.1      <  S   0:500(500)               win 65535  <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, FO, nop, nop, mpcapable v1 flags[flag_h] nokey>
 +0.0      >  S.  0:0(0)          ack 501             <mss 1460, sackOK, TS val 100 ecr 100, nop, wscale 8,               mpcapable v1 flags[flag_h] key[skey]>
-+0.4      <   .  501:501(0)      ack 1    win 450    <nop, nop,         TS val 100 ecr 100,                              mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.2      <   .  501:501(0)      ack 1    win 450    <nop, nop,         TS val 100 ecr 100,                              mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 
 +0.01   accept(3, ..., ...) = 4
 

--- a/gtests/net/mptcp/mp_join/mp_join_client.pkt
+++ b/gtests/net/mptcp/mp_join/mp_join_client.pkt
@@ -10,7 +10,7 @@
 
 +0.0  connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
 +0.0    >  addr[caddr0] > addr[saddr0]  S   0:0(0)                        <mss 1460, sackOK, TS val 4074410674 ecr 0,          nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.4    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.2    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0    >                                .  1:1(0)      ack 1             <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 +0.2  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
@@ -24,7 +24,7 @@
 
 
 +0.0    >               > addr[saddr1]  S   0:0(0)                        <mss 1460, sackOK, TS val 448955294 ecr 0,         nop, wscale 8, mp_join_syn     address_id=0 token=sha256_32(skey)>
-+0.4    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
++0.2    <                               S.  0:0(0)      ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
 +0.0    >                                .  1:1(0)      ack 1             <nop, nop,         TS val 448955294 ecr 448955294,                mp_join_ack                  sender_hmac=auto>
 
 +0.0    <                                .  1:1(0)      ack 1  win 256    <nop, nop,         TS val 448955294 ecr 448955294, dss dack8=3   nocs>

--- a/gtests/net/mptcp/mp_join/mp_join_server.pkt
+++ b/gtests/net/mptcp/mp_join/mp_join_server.pkt
@@ -13,7 +13,7 @@
 
 +0.1    <  addr[caddr0] > addr[saddr0]  S   0:0(0)         win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 0,          nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
 +0.0    >                               S.  0:0(0)  ack 1             <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.4    <                                .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.2    <                                .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0    accept(3, ..., ...) = 4
 
 +0.0    <                               P.  1:3(2)  ack 1  win 256    <nop, nop,         TS val 4074418292 ecr 4074410674,                mpcapable v1 flags[flag_h] key[skey, ckey] mpcdatalen 2, nop, nop>

--- a/gtests/net/mptcp/mp_prio/mp_prio_server.pkt
+++ b/gtests/net/mptcp/mp_prio/mp_prio_server.pkt
@@ -12,7 +12,7 @@
 
 +0.1    <  addr[caddr0] > addr[saddr0]  S   0:0(0)               win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 0,          nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
 +0.0    >                               S.  0:0(0)        ack 1             <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
-+0.4    <                                .  1:1(0)        ack 1  win 256    <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0.2    <                                .  1:1(0)        ack 1  win 256    <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey=2, skey]>
 +0    accept(3, ..., ...) = 4
 
 +0.2    <                               P.  1:3(2)        ack 1  win 256    <nop, nop, TS val 4074418292 ecr 4074410674,                        mpcapable v1 flags[flag_h] key[skey, ckey] mpcdatalen 2, nop, nop>
@@ -29,7 +29,7 @@
 // create subflow
 +0.1    <  addr[caddr1] > addr[saddr0]  S   0:0(0)               win 65535  <mss 1460, sackOK, TS val 448955294 ecr 0,         nop, wscale 8, mp_join_syn     backup=1 address_id=1 token=sha256_32(skey)>
 +0.0    >                               S.  0:0(0)        ack 1             <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack          address_id=0 sender_hmac=auto>
-+0.4    <                                .  1:1(0)        ack 1  win 256    <nop, nop, TS val 448955294 ecr 448955294,                        mp_join_ack sender_hmac=auto>
++0.2    <                                .  1:1(0)        ack 1  win 256    <nop, nop, TS val 448955294 ecr 448955294,                        mp_join_ack sender_hmac=auto>
 +0.0    >                                .  1:1(0)        ack 1             <nop, nop, TS val 448955294 ecr 448955294,                        dss dack4=5 nocs>
 
 // more inbound data and MP_PRIO to flip backup -> active

--- a/gtests/net/mptcp/sockopts/sockopt_set_ip_tos_invalid_v4.pkt
+++ b/gtests/net/mptcp/sockopts/sockopt_set_ip_tos_invalid_v4.pkt
@@ -11,7 +11,7 @@
 +0.0  connect(7, ..., ...) = -1  EINPROGRESS (Operation now in progress)
 
 +0.0  >  [tos 0x04]  addr[caddr0] > addr[saddr0]  S   0:0(0)                    <mss 1460, sackOK, TS val 4074410674 ecr 0,          nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.4  <                                           S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.2  <                                           S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0  >  [tos 0x04]                                .  1:1(0)  ack 1             <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 +0.0  fcntl(7, F_SETFL, O_RDWR) = 0   // set back to blocking
@@ -26,7 +26,7 @@
 +0.0  setsockopt(7, SOL_IP, IP_TOS, [7], 4) = 0
 
 +0.0  >  [tos 0x04]               > addr[saddr1]  S   0:0(0)                    <mss 1460, sackOK, TS val 448955294 ecr 0,         nop, wscale 8, mp_join_syn     address_id=0 token=sha256_32(skey)>
-+0.4  <                                           S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
++0.2  <                                           S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
 +0.0  >  [tos 0x04]                                .  1:1(0)  ack 1             <nop, nop,         TS val 448955294 ecr 448955294,                mp_join_ack                  sender_hmac=auto>
 +0.0  <                                            .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 448955294 ecr 448955294,   dss dack8=3   nocs>
 

--- a/gtests/net/mptcp/sockopts/sockopt_set_ip_tos_valid_v4.pkt
+++ b/gtests/net/mptcp/sockopts/sockopt_set_ip_tos_valid_v4.pkt
@@ -11,7 +11,7 @@
 +0.0  connect(7, ..., ...) = -1  EINPROGRESS (Operation now in progress)
 
 +0.0  >  [tos 0x04]  addr[caddr0] > addr[saddr0]  S   0:0(0)                    <mss 1460, sackOK, TS val 4074410674 ecr 0,          nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.4  <                                           S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.2  <                                           S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 4074410674 ecr 4074410674, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0  >  [tos 0x04]                                .  1:1(0)  ack 1             <nop, nop,         TS val 4074410674 ecr 4074410674,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 +0.0  fcntl(7, F_SETFL, O_RDWR) = 0   // set back to blocking
@@ -26,7 +26,7 @@
 +0.0  setsockopt(7, SOL_IP, IP_TOS, [7], 4) = 0
 
 +0.0  >  [tos 0x04]               > addr[saddr1]  S   0:0(0)                    <mss 1460, sackOK, TS val 448955294 ecr 0,         nop, wscale 8, mp_join_syn     address_id=0 token=sha256_32(skey)>
-+0.4  <                                           S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
++0.2  <                                           S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 448955294 ecr 448955294, nop, wscale 8, mp_join_syn_ack address_id=1 sender_hmac=auto>
 +0.0  >  [tos 0x04]                                .  1:1(0)  ack 1             <nop, nop,         TS val 448955294 ecr 448955294,                mp_join_ack                  sender_hmac=auto>
 +0.0  <                                            .  1:1(0)  ack 1  win 256    <nop, nop,         TS val 448955294 ecr 448955294,   dss dack8=3   nocs>
 

--- a/gtests/net/mptcp/syscalls/connect_close.pkt
+++ b/gtests/net/mptcp/syscalls/connect_close.pkt
@@ -11,7 +11,7 @@
 
 +0.0    connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
 +0.0      >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.4      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.2      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 // client shutdown before any incoming DSS

--- a/gtests/net/mptcp/syscalls/connect_close_ack_ooo.pkt
+++ b/gtests/net/mptcp/syscalls/connect_close_ack_ooo.pkt
@@ -11,7 +11,7 @@
 
 +0.0    connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
 +0.0      >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.4      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.2      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 // client shutdown before any incoming DSS, DATA_FIN is acked by an OoO packet

--- a/gtests/net/mptcp/syscalls/connect_close_full.pkt
+++ b/gtests/net/mptcp/syscalls/connect_close_full.pkt
@@ -11,7 +11,7 @@
 
 +0.0    connect(3, ..., ...) = -1  EINPROGRESS (Operation now in progress)
 +0.0      >  S   0:0(0)                    <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
-+0.4      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.2      <  S.  0:0(0)  ack 1  win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
 +0.0      >   .  1:1(0)  ack 1             <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
 
 // client shutdown before any incoming DSS


### PR DESCRIPTION
Linked to commit de04bbf44856e95001e0813593a96b1089fa7c98.

In 'debug' mode, that seems to cause more troubles, especially to inject the 3rd ACK with a delay of 0.4 seconds:

    not ok 20 packetdrill: mptcp/dss/dss_fin_retrans_established.pkt (ipv4-mapped-v6)
    # dss_fin_retrans_established.pkt:17: error handling packet: live packet field tcp_syn: expected: 0 (0x0) vs actual: 1 (0x1)
    # script packet:  1.242992 . 1:1(0) ack 1 <dss dack4 16777216 dsn8 72057594037927936 ssn 0 dll 256 no_checksum flags: MmAF,nop,nop>
    # actual packet:  1.191035 S. 0:0(0) ack 1 win 65535 <mss 1460,nop,nop,sackOK,nop,wscale 8,mp_capable v1 flags: |H| sender_key: 8142903674301043200>
    not ok 23 packetdrill: mptcp/dss/dss_fin_retrans_last_ack.pkt (ipv4-mapped-v6)
    # dss_fin_retrans_last_ack.pkt:17: error handling packet: live packet field tcp_syn: expected: 0 (0x0) vs actual: 1 (0x1)
    # script packet:  1.232463 . 1:1(0) ack 1 <dss dack4 16777216 dsn8 72057594037927936 ssn 0 dll 256 no_checksum flags: MmAF,nop,nop>
    # actual packet:  1.180999 S. 0:0(0) ack 1 win 65535 <mss 1460,nop,nop,sackOK,nop,wscale 8,mp_capable v1 flags: |H| sender_key: 11951288142622606755>
    not ok 25 packetdrill: mptcp/dss/dss_fin_server.pkt (ipv4)
    # dss_fin_server.pkt:17: error handling packet: live packet field ipv4_total_length: expected: 48 (0x30) vs actual: 64 (0x40)
    # script packet:  1.232419 . 1:1(0) ack 1 <dss dack4 33554432 flags: A>
    # actual packet:  1.180133 S. 0:0(0) ack 1 win 65535 <mss 1460,nop,nop,sackOK,nop,wscale 8,mp_capable v1 flags: |H| sender_key: 5813351207709977825>

That seems to be because this 3rd ACK packet is injected with a too long delay, one second after the SYN!

Link: https://github.com/multipath-tcp/mptcp_net-next/actions/runs/23047176860