### PR TITLE
mptcp: reproducer for `recv(MSG_PEEK | MSG_WAITALL)`

### DIFF
--- a/gtests/net/mptcp/syscalls/recv_peek_waitall.pkt
+++ b/gtests/net/mptcp/syscalls/recv_peek_waitall.pkt
@@ -1,0 +1,33 @@
+// connect() function, connection initiated by the kernel
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
+0.0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0.0    setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
++0.0    fcntl(3, F_GETFL) = 0x2 (flags O_RDWR)
++0.0    fcntl(3, F_SETFL, O_RDWR|O_NONBLOCK) = 0
+
+// Establish connection and verify that there was no error.
+
++0.0    connect(3, ..., ...) = -1 EINPROGRESS (Operation now in progress)
++0.0      >  S   0:0(0)                               <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 8, mpcapable v1 flags[flag_h] nokey>
++0.1      <  S.  0:0(0)          ack 1     win 65535  <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey=2]>
++0.0      >   .  1:1(0)          ack 1                <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey, skey]>
+
++0.200  getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.205  fcntl(3, F_SETFL, O_RDWR) = 0   // set back to blocking
+
+// Force 4th ACK
++0.1    write(3, ..., 1000) = 1000
++0.0      >  P.  1:1001(1000)    ack 1                <nop, nop, TS val 100 ecr 700, mpcapable v1 flags[flag_h] key[ckey, skey] mpcdatalen 1000, nop, nop>
++0.01     <   .  1:1(0)          ack 1001  win 225    <nop, nop, TS val 700 ecr 100, dss dack8=1001 nocs>
+
++0.01     <   .  1:1001(1000)    ack 1001  win 225    <nop, nop, TS val 700 ecr 100, dss dack8=1001 dsn8=1    ssn=1    dll=1000 nocs, nop, nop>
++0.0      >   .  1001:1001(0)    ack 1001             <nop, nop, TS val 100 ecr 700, dss dack8=1001                    dll=0    nocs>
+
+// read with PEEK and WAIT_ALL: it should come after 1 second
++0.0...1.0  recv(3, ..., 2000, MSG_PEEK | MSG_WAITALL) = 2000
+
+// inject the rest after 1 second
++1.00     <   .  1001:2001(1000) ack 1001  win 225    <nop, nop, TS val 700 ecr 100, dss dack8=1001 dsn8=1001 ssn=1001 dll=1000 nocs, nop, nop>
++0.0      >   .  1001:1001(0)    ack 2001             <nop, nop, TS val 100 ecr 700, dss dack8=2001                    dll=0    nocs>


### PR DESCRIPTION
A first packet of 1000B is received, then it waits for 1000B more, which is sent with a delay of 1 second.

With the current kernel versions, this test stalls and stops after 180 seconds when launched with 'run_all.py'. Without a fix, the packetdrill program uses 100% of CPU while waiting.

Link: https://lore.kernel.org/20260302052651.1466983-1-lixiasong1@huawei.com