### PR TITLE
mptcp: add-addr: sending ADD_ADDR with port

### DIFF
--- a/gtests/net/mptcp/add_addr/add_addr4_port_server.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr4_port_server.pkt
@@ -1,0 +1,31 @@
+// connection initiated by packetdrill
+--tolerance_usecs=350000
+`../common/defaults.sh`
+
+// an address not used in packetdrill defaults
++0     `ip mptcp endpoint flush`
+// Add the address to be able to create the listener socket without errors
++0     `ip addr add 198.51.100.2/32 dev $OPT_LOCAL_DEV`
++0     `ip mptcp endpoint add 198.51.100.2 port 4321 id 1 signal`
+
++0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
+
++0     bind(3, ..., ...) = 0
++0     listen(3, 1) = 0
++0.1     <  S   0:0(0)         win 32792  <mss 1460, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.2     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0     accept(3, ..., ...) = 4
+
+// ADD_ADDR is sent directly (>= 5.12), not after first data (< 5.12)
++0       >   .  1:1(0)        ack 1              <add_address address_id=1 addr[ep=inet_addr("198.51.100.2")] port=4321 hmac=auto, nop, nop>
++0       <   .  1:1(0)        ack 1     win 257  <add_address address_id=1 addr[ep=inet_addr("198.51.100.2")] port=4321 addr_echo, nop, nop>
+
+// read and ack 1 data segment
++0.1     <  P.  1:1001(1000)  ack 1     win 450  <nop, nop,                          dss dack8=1    dsn8=1 ssn=1 dll=1000 nocs>
++0       >   .  1:1(0)        ack 1001                                              <dss dack8=1001        ssn=1 dll=0 nocs>
++0.3   read(4, ..., 1000) = 1000
+
++0     close(4) = 0
++0       >   .  1:1(0)        ack 1001                                              <dss dack8=1001 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>

--- a/gtests/net/mptcp/add_addr/add_addr4_port_ts_server.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr4_port_ts_server.pkt
@@ -1,0 +1,31 @@
+// connection initiated by packetdrill
+--tolerance_usecs=350000
+`../common/defaults.sh`
+
+// an address not used in packetdrill defaults
++0     `ip mptcp endpoint flush`
+// Add the address to be able to create the listener socket without errors
++0     `ip addr add 198.51.100.2/32 dev $OPT_LOCAL_DEV`
++0     `ip mptcp endpoint add 198.51.100.2 port 4321 id 1 signal`
+
++0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
+
++0     bind(3, ..., ...) = 0
++0     listen(3, 1) = 0
++0.1     <  S   0:0(0)         win 32792  <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0       >  S.  0:0(0)  ack 1             <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.2     <   .  1:1(0)  ack 1  win 257    <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0     accept(3, ..., ...) = 4
+
+// ADD_ADDR is sent directly (>= 5.12), not after first data (< 5.12)
++0       >   .  1:1(0)        ack 1              <nop, nop, TS val 700 ecr 100, add_address address_id=1 addr[ep=inet_addr("198.51.100.2")] port=4321 hmac=auto, nop, nop>
++0       <   .  1:1(0)        ack 1     win 257  <nop, nop, TS val 100 ecr 700, add_address address_id=1 addr[ep=inet_addr("198.51.100.2")] port=4321 addr_echo, nop, nop>
+
+// read and ack 1 data segment
++0.1     <  P.  1:1001(1000)  ack 1     win 450            <TS val 100 ecr 700, dss dack8=1    dsn8=1 ssn=1 dll=1000 nocs>
++0       >   .  1:1(0)        ack 1001           <nop, nop, TS val 700 ecr 100, dss dack8=1001        ssn=1 dll=0 nocs>
++0.3   read(4, ..., 1000) = 1000
+
++0     close(4) = 0
++0       >   .  1:1(0)        ack 1001           <nop, nop, TS val 700 ecr 100, dss dack8=1001 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>

--- a/gtests/net/mptcp/add_addr/add_addr6_port_server.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr6_port_server.pkt
@@ -1,0 +1,31 @@
+// connection initiated by packetdrill
+--tolerance_usecs=350000
+`../common/defaults.sh`
+
+// an address not used in packetdrill defaults
++0     `ip mptcp endpoint flush`
+// Add the address to be able to create the listener socket without errors
++0     `ip -6 addr add 2001:db8::c1a0/32 dev $OPT_LOCAL_DEV`
++0     `ip -6 mptcp endpoint add 2001:db8::c1a0 port 4321 id 2 signal`
+
++0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
+
++0     bind(3, ..., ...) = 0
++0     listen(3, 1) = 0
++0.1     <  S   0:0(0)         win 32792  <mss 1460, sackOK, nop, nop, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0       >  S.  0:0(0)  ack 1             <mss 1460, nop, nop, sackOK, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.2     <   .  1:1(0)  ack 1  win 257                                               <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0     accept(3, ..., ...) = 4
+
+// ADD_ADDR is sent directly (>= 5.12), not after first data (< 5.12)
++0       >   .  1:1(0)        ack 1              <add_address address_id=2 addr[ep=inet6_addr("2001:db8::c1a0")] port=4321 hmac=auto, nop, nop>
++0       <   .  1:1(0)        ack 1     win 257  <add_address address_id=2 addr[ep=inet6_addr("2001:db8::c1a0")] port=4321 addr_echo, nop, nop>
+
+// read and ack 1 data segment
++0.1     <  P.  1:1001(1000)  ack 1     win 450  <nop, nop, dss dack8=1    dsn8=1 ssn=1 dll=1000 nocs>
++0       >   .  1:1(0)        ack 1001                     <dss dack8=1001        ssn=1 dll=0    nocs>
++0.3   read(4, ..., 1000) = 1000
+
++0     close(4) = 0
++0       >   .  1:1(0)        ack 1001                     <dss dack8=1001 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>

--- a/gtests/net/mptcp/add_addr/add_addr6_port_ts_server.pkt
+++ b/gtests/net/mptcp/add_addr/add_addr6_port_ts_server.pkt
@@ -1,0 +1,36 @@
+// connection initiated by packetdrill
+--tolerance_usecs=350000
+`../common/defaults.sh`
+
+// an address not used in packetdrill defaults
++0     `ip mptcp endpoint flush`
+// Add the address to be able to create the listener socket without errors
++0     `ip -6 addr add 2001:db8::c1a0/32 dev $OPT_LOCAL_DEV`
++0     `ip -6 mptcp endpoint add 2001:db8::c1a0 port 4321 id 2 signal`
+
++0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
+
++0     bind(3, ..., ...) = 0
++0     listen(3, 1) = 0
++0.1     <  S   0:0(0)         win 32792  <mss 1460, sackOK, TS val 100 ecr 0,   nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0       >  S.  0:0(0)  ack 1             <mss 1460, sackOK, TS val 700 ecr 100, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.2     <   .  1:1(0)  ack 1  win 257    <nop, nop,         TS val 100 ecr 700,                mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0     accept(3, ..., ...) = 4
+
+// ADD_ADDR is sent directly (>= 5.12), not after first data (< 5.12)
+// Note: for the moment, it is not possible to send ADD_ADDRv6 + port + TS.
+// Send a plain ACK instead:
++0       >   .  1:1(0)        ack 1              <nop, nop, TS val 700 ecr 100, dss dack4=1 nocs>
+
+// When https://github.com/multipath-tcp/mptcp_net-next/issues/448 will be implemented:
+// +0    >   .  1:1(0)        ack 1              <add_address address_id=2 addr[ep=inet6_addr("2001:db8::c1a0")] port=4321 hmac=auto, nop, nop>
+// +0    <   .  1:1(0)        ack 1     win 257  <add_address address_id=2 addr[ep=inet6_addr("2001:db8::c1a0")] port=4321 addr_echo, nop, nop>
+
+// read and ack 1 data segment
++0.1     <  P.  1:1001(1000)  ack 1     win 450            <TS val 100 ecr 700, dss dack8=1    dsn8=1 ssn=1 dll=1000 nocs>
++0       >   .  1:1(0)        ack 1001           <nop, nop, TS val 700 ecr 100, dss dack8=1001        ssn=1 dll=0 nocs>
++0.3   read(4, ..., 1000) = 1000
+
++0     close(4) = 0
++0       >   .  1:1(0)        ack 1001           <nop, nop, TS val 700 ecr 100, dss dack8=1001 dsn8=1 ssn=0 dll=1 nocs fin, nop, nop>


### PR DESCRIPTION
Up to now, only the reception of these ADD_ADDR with ports was being validated. These new simple tests cover the sending part.

For the sending part, it is required to tell the PM to create such ADD_ADDR with a specific port. Prior to that, a listener socket will be created to accept future MP_JOIN sent to this other port number. It is then also required to do something to avoid a "create listen socket error: -99", e.g. attaching the new address to the interface.

Note: it is currently not possible to send an ADD_ADDRv6 with a port when TCP timestamps is being used [1]. Instead, the test just checks that a "pure ACK" is sent.

Link: https://github.com/multipath-tcp/mptcp_net-next/issues/448 [1]