### PR TITLE
mptcp: fastclose: validate send part with SO_LINGER

### DIFF
--- a/gtests/net/mptcp/fastclose/send_fastclose_linger_no_data.pkt
+++ b/gtests/net/mptcp/fastclose/send_fastclose_linger_no_data.pkt
@@ -1,0 +1,19 @@
+// Verify a RST is correctly emitted when SO_LINGER(1, 0) + close() is used.
+// no data exchanged
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
++0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
+
++0     bind(3, ..., ...) = 0
++0     listen(3, 1) = 0
++0.0     <  S   0:0(0)                     win 65535  <mss 1460, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0.0     >  S.  0:0(0)           ack 1                <mss 1460, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.1     <   .  1:1(0)           ack 1     win 256                             <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0     accept(3, ..., ...) = 4
+
++0 setsockopt(4, SOL_SOCKET, SO_LINGER, {onoff=1, linger=0}, 8) = 0
++0 close(4) = 0
+
++0       >  R.  1:1(0)           ack 1                          <mp_fastclose, mp_reset 0>

--- a/gtests/net/mptcp/fastclose/send_fastclose_linger_read_data.pkt
+++ b/gtests/net/mptcp/fastclose/send_fastclose_linger_read_data.pkt
@@ -1,0 +1,24 @@
+// Verify a RST is correctly emitted when SO_LINGER(1, 0) + close() is used.
+// With received data has been read
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
++0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
+
++0     bind(3, ..., ...) = 0
++0     listen(3, 1) = 0
++0.0     <  S   0:0(0)                     win 65535  <mss 1460, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0.0     >  S.  0:0(0)           ack 1                <mss 1460, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.1     <   .  1:1(0)           ack 1     win 256                             <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0     accept(3, ..., ...) = 4
+
++0.0     <  P.  1:1001(1000)     ack 1     win 450    <nop, nop, dss dack8=1    dsn8=1    ssn=1    dll=1000 nocs>
++0.0     >   .  1:1(0)           ack 1001                       <dss dack8=1001 nocs>
+
++0 read(4, ..., 1000) = 1000
+
++0 setsockopt(4, SOL_SOCKET, SO_LINGER, {onoff=1, linger=0}, 8) = 0
++0 close(4) = 0
+
++0       >  R.  1:1(0)           ack 1001                       <mp_fastclose, mp_reset 0>

--- a/gtests/net/mptcp/fastclose/send_fastclose_linger_unread_data.pkt
+++ b/gtests/net/mptcp/fastclose/send_fastclose_linger_unread_data.pkt
@@ -1,0 +1,23 @@
+// Verify a RST is correctly emitted when SO_LINGER(1, 0) + close() is used.
+// With unread data received in the queue
+--tolerance_usecs=100000
+`../common/defaults.sh`
+
++0     socket(..., SOCK_STREAM, IPPROTO_MPTCP) = 3
++0     setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
+
++0     bind(3, ..., ...) = 0
++0     listen(3, 1) = 0
++0.0     <  S   0:0(0)                     win 65535  <mss 1460, nop, wscale 7, mpcapable v1 flags[flag_h] nokey>
++0.0     >  S.  0:0(0)           ack 1                <mss 1460, nop, wscale 8, mpcapable v1 flags[flag_h] key[skey]>
++0.1     <   .  1:1(0)           ack 1     win 256                             <mpcapable v1 flags[flag_h] key[ckey=2, skey]>
++0     accept(3, ..., ...) = 4
+
++0.0     <  P.  1:1001(1000)     ack 1     win 450    <nop, nop, dss dack8=1    dsn8=1    ssn=1    dll=1000 nocs>
++0.0     >   .  1:1(0)           ack 1001                       <dss dack8=1001 nocs>
+
+// SO_LINGER(1, 0) not needed here: RST expected because of unread data.
++0 setsockopt(4, SOL_SOCKET, SO_LINGER, {onoff=1, linger=0}, 8) = 0
++0 close(4) = 0
+
++0       >  R.  1:1(0)           ack 1001                       <mp_fastclose, mp_reset 0>

--- a/gtests/net/tcp/close/mptcp-like/send_reset_linger_no_data.pkt
+++ b/gtests/net/tcp/close/mptcp-like/send_reset_linger_no_data.pkt
@@ -1,0 +1,21 @@
+// Verify a RST is correctly emitted when SO_LINGER(1, 0) + close() is used.
+// no data exchanged
+
+`../../common/defaults.sh`
+
+// Initialize a server socket.
+    0 socket(..., SOCK_STREAM, IPPROTO_TCP) = 3
+   +0 setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
+   +0 bind(3, ..., ...) = 0
+   +0 listen(3, 1) = 0
+
+   +0 < S 0:0(0) win 32792 <mss 1000,sackOK,nop,nop,nop,wscale 7>
+   +0 > S. 0:0(0) ack 1 <mss 1460,nop,nop,sackOK,nop,wscale 8>
+   +0 < . 1:1(0) ack 1 win 257
+
+   +0 accept(3, ..., ...) = 4
+
+   +0 setsockopt(4, SOL_SOCKET, SO_LINGER, {onoff=1, linger=0}, 8) = 0
+   +0 close(4) = 0
+
+   +0 > R. 1:1(0) ack 1

--- a/gtests/net/tcp/close/mptcp-like/send_reset_linger_read_data.pkt
+++ b/gtests/net/tcp/close/mptcp-like/send_reset_linger_read_data.pkt
@@ -1,0 +1,26 @@
+// Verify a RST is correctly emitted when SO_LINGER(1, 0) + close() is used.
+// With received data has been read
+
+`../../common/defaults.sh`
+
+// Initialize a server socket.
+    0 socket(..., SOCK_STREAM, IPPROTO_TCP) = 3
+   +0 setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
+   +0 bind(3, ..., ...) = 0
+   +0 listen(3, 1) = 0
+
+   +0 < S 0:0(0) win 32792 <mss 1000,sackOK,nop,nop,nop,wscale 7>
+   +0 > S. 0:0(0) ack 1 <mss 1460,nop,nop,sackOK,nop,wscale 8>
+   +0 < . 1:1(0) ack 1 win 257
+
+   +0 accept(3, ..., ...) = 4
+
+   +0 < P. 1:1001(1000) ack 1 win 450
+   +0 > . 1:1(0) ack 1001
+
+   +0 read(4, ..., 1000) = 1000
+
+   +0 setsockopt(4, SOL_SOCKET, SO_LINGER, {onoff=1, linger=0}, 8) = 0
+   +0 close(4) = 0
+
+   +0 > R. 1:1(0) ack 1001

--- a/gtests/net/tcp/close/mptcp-like/send_reset_linger_unread_data.pkt
+++ b/gtests/net/tcp/close/mptcp-like/send_reset_linger_unread_data.pkt
@@ -1,0 +1,25 @@
+// Verify a RST is correctly emitted when SO_LINGER(1, 0) + close() is used.
+// With unread data received in the queue
+
+`../../common/defaults.sh`
+
+// Initialize a server socket.
+    0 socket(..., SOCK_STREAM, IPPROTO_TCP) = 3
+   +0 setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
+   +0 bind(3, ..., ...) = 0
+   +0 listen(3, 1) = 0
+
+   +0 < S 0:0(0) win 32792 <mss 1000,sackOK,nop,nop,nop,wscale 7>
+   +0 > S. 0:0(0) ack 1 <mss 1460,nop,nop,sackOK,nop,wscale 8>
+   +0 < . 1:1(0) ack 1 win 257
+
+   +0 accept(3, ..., ...) = 4
+
+   +0 < P. 1:1001(1000) ack 1 win 450
+   +0 > . 1:1(0) ack 1001
+
+// SO_LINGER(1, 0) not needed here: RST expected because of unread data.
+   +0 setsockopt(4, SOL_SOCKET, SO_LINGER, {onoff=1, linger=0}, 8) = 0
+   +0 close(4) = 0
+
+   +0 > R. 1:1(0) ack 1001


### PR DESCRIPTION
RST + MP_FASTCLOSE + MP_RESET are supposed to be generated when SO_LINGER(on, 0) is set, similar to TCP with a plain RST.

This validation is now done here, with both TCP and MPTCP, with read data, unread data, and no data.

Note that when there is unread data, a RST is expected at close() time, even when SO_LINGER(1, 0) has not been set.

Up to now, the kernel didn't respect SO_LINGER(1, 0) on an MPTCP socket. This is going to change, and this test is there to validate the modification.