### PR TITLE
mptcp: sockopt: rcvbuf: fix ssthresh val

### DIFF
--- a/gtests/net/mptcp/sockopts/sockopt_rcvbuf.pkt
+++ b/gtests/net/mptcp/sockopts/sockopt_rcvbuf.pkt
@@ -19,7 +19,7 @@
 
 // Record tcpi_rcv_space (rcv_ssthresh) before SO_RCVBUF.
 // With default tcp_rmem[2], this should be a large value.
-+0.0  %{ assert tcpi_rcv_ssthresh == 268552, tcpi_rcv_space }%
++0.0  %{ print(tcpi_rcv_ssthresh); assert tcpi_rcv_ssthresh > 8192, tcpi_rcv_space }%
 
 // Set SO_RCVBUF to a small value:
 //   kernel doubles 8192 -> sk_rcvbuf = 16384
@@ -31,7 +31,7 @@
 // Without the fix: window_clamp not updated, rcv_ssthresh stays at the old
 // large value, assert fails.
 // With the fix: rcv_ssthresh <= 8192, assert passes.
-+0.0  %{ assert tcpi_rcv_ssthresh == 8192, tcpi_rcv_space }%
++0.0  %{ print(tcpi_rcv_ssthresh); assert tcpi_rcv_ssthresh == 8192, tcpi_rcv_space }%
 
 // Clean close
 +0     close(4) = 0


### PR DESCRIPTION
On my side, the default value is at 268540, not 268552.

The default value doesn't matter too much: what is important is to see that after the setsockopt, the value is at 8192.

While at it, print the value to stdout by default, helpful in case of issues.